### PR TITLE
fix: pre-release polish — entry point, placeholders, README rewrite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,17 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.0] - 2024-01-01
+## [0.1.0] - 2025-02-15
 
 ### Added
 - Initial release of Yuque MCP Server
-- Complete implementation of 25 Yuque API tools
-- Support for both stdio and streamable-http transports
+- 25 tools covering Yuque API (user, repo, doc, toc, search, group, stats, version)
+- Stdio transport for local MCP clients (Claude Desktop, Cursor, Claude Code)
 - TypeScript implementation with strict mode
-- Comprehensive test coverage with vitest
-- AI-optimized response formatting
-- Flexible authentication via environment variable or CLI argument
-- Complete documentation (README in English and Chinese)
+- Zod-based parameter validation for all tools
+- AI-optimized response formatting (minimal token usage)
+- Authentication via `YUQUE_TOKEN` environment variable or `--token` CLI argument
+- Comprehensive test suite with vitest
+- ESLint + Prettier code quality tooling
+- CI pipeline (Node 18/20/22)
+- Docker support
+- Documentation in English and Chinese
 
-[Unreleased]: https://github.com/yourusername/yuque-mcp-server/compare/v0.1.0...HEAD
-[0.1.0]: https://github.com/yourusername/yuque-mcp-server/releases/tag/v0.1.0
+[Unreleased]: https://github.com/chen201724/yuque-mcp-server/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/chen201724/yuque-mcp-server/releases/tag/v0.1.0

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -18,7 +18,7 @@ Unacceptable behavior:
 
 ## Enforcement
 
-Report issues to [INSERT EMAIL]. All complaints will be reviewed promptly.
+Report issues via [GitHub Issues](https://github.com/chen201724/yuque-mcp-server/issues). All complaints will be reviewed promptly.
 
 ## Attribution
 

--- a/README.md
+++ b/README.md
@@ -1,121 +1,134 @@
 # Yuque MCP Server
 
+[![CI](https://github.com/chen201724/yuque-mcp-server/actions/workflows/ci.yml/badge.svg)](https://github.com/chen201724/yuque-mcp-server/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![TypeScript](https://img.shields.io/badge/TypeScript-5.7-blue.svg)](https://www.typescriptlang.org/)
 [![MCP](https://img.shields.io/badge/MCP-1.0-green.svg)](https://modelcontextprotocol.io/)
 
-Official-quality MCP (Model Context Protocol) server for Yuque (语雀) API. This server exposes Yuque's knowledge base capabilities to AI assistants through the standardized MCP interface.
+MCP server for [Yuque (语雀)](https://www.yuque.com/) — expose your Yuque knowledge base to AI assistants through the [Model Context Protocol](https://modelcontextprotocol.io/).
 
 [中文文档](./README.zh-CN.md)
 
 ## Features
 
-- **Complete API Coverage**: All 25 Yuque API endpoints implemented
-- **Dual Transport**: Supports both stdio and streamable-http transports
-- **Type-Safe**: Full TypeScript implementation with strict mode
-- **AI-Optimized**: Response formatting designed to minimize token usage
-- **Flexible Auth**: Environment variable or CLI argument authentication
-- **Well-Tested**: Comprehensive test coverage with vitest
-- **Production-Ready**: Follows Ant Design open-source standards
-
-## Installation
-
-```bash
-npm install -g yuque-mcp-server
-```
-
-Or use directly with npx:
-
-```bash
-npx yuque-mcp-server --token=YOUR_TOKEN
-```
+- **25 Tools** — Complete coverage of Yuque API (docs, repos, search, groups, stats, TOC, versions)
+- **Stdio Transport** — Works with Claude Desktop, Cursor, Claude Code, Windsurf, and any MCP-compatible client
+- **Type-Safe** — Full TypeScript with strict mode + Zod parameter validation
+- **AI-Optimized** — Response formatting designed to minimize token usage
+- **Well-Tested** — Unit tests with vitest, CI on Node 18/20/22
 
 ## Quick Start
 
 ### 1. Get Your Yuque API Token
 
-Visit [Yuque Settings](https://www.yuque.com/settings/tokens) to generate your API token.
+Visit [Yuque Developer Settings](https://www.yuque.com/settings/tokens) to generate a personal API token.
 
-### 2. Run the Server
+### 2. Configure Your MCP Client
 
-**Stdio mode (for MCP clients):**
+#### Claude Code
 
 ```bash
+claude mcp add yuque -- npx -y yuque-mcp-server --token=YOUR_TOKEN
+```
+
+Or add to `~/.claude/claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "yuque": {
+      "command": "npx",
+      "args": ["-y", "yuque-mcp-server"],
+      "env": {
+        "YUQUE_TOKEN": "YOUR_TOKEN"
+      }
+    }
+  }
+}
+```
+
+#### Claude Desktop
+
+Add to your Claude Desktop config (`~/Library/Application Support/Claude/claude_desktop_config.json` on macOS):
+
+```json
+{
+  "mcpServers": {
+    "yuque": {
+      "command": "npx",
+      "args": ["-y", "yuque-mcp-server"],
+      "env": {
+        "YUQUE_TOKEN": "YOUR_TOKEN"
+      }
+    }
+  }
+}
+```
+
+#### Cursor
+
+Add to `.cursor/mcp.json` in your project root:
+
+```json
+{
+  "mcpServers": {
+    "yuque": {
+      "command": "npx",
+      "args": ["-y", "yuque-mcp-server"],
+      "env": {
+        "YUQUE_TOKEN": "YOUR_TOKEN"
+      }
+    }
+  }
+}
+```
+
+#### Global Install (alternative)
+
+```bash
+npm install -g yuque-mcp-server
 export YUQUE_TOKEN=your_token_here
 yuque-mcp-server
 ```
 
-Or with CLI argument:
-
-```bash
-yuque-mcp-server --token=your_token_here
-```
-
-**HTTP mode (for testing):**
-
-```bash
-export YUQUE_TOKEN=your_token_here
-npm start
-```
-
-The server will run on `http://localhost:3000` by default.
-
 ## Available Tools
 
-### User & Groups (2 tools)
-- `yuque_get_user` - Get current user information
-- `yuque_list_groups` - List user's groups/teams
-
-### Search (1 tool)
-- `yuque_search` - Search documents, repos, or users
-
-### Repositories (5 tools)
-- `yuque_list_repos` - List repos for user or group
-- `yuque_get_repo` - Get repo details
-- `yuque_create_repo` - Create new repo
-- `yuque_update_repo` - Update repo
-- `yuque_delete_repo` - Delete repo
-
-### Documents (5 tools)
-- `yuque_list_docs` - List documents in repo
-- `yuque_get_doc` - Get document with full content
-- `yuque_create_doc` - Create new document
-- `yuque_update_doc` - Update document
-- `yuque_delete_doc` - Delete document
-
-### Table of Contents (2 tools)
-- `yuque_get_toc` - Get repo TOC
-- `yuque_update_toc` - Update repo TOC
-
-### Document Versions (2 tools)
-- `yuque_list_doc_versions` - List document versions
-- `yuque_get_doc_version` - Get specific version
-
-### Group Management (3 tools)
-- `yuque_list_group_members` - List group members
-- `yuque_update_group_member` - Update member role
-- `yuque_remove_group_member` - Remove member
-
-### Statistics (4 tools)
-- `yuque_group_stats` - Group statistics
-- `yuque_group_member_stats` - Member statistics
-- `yuque_group_book_stats` - Book statistics
-- `yuque_group_doc_stats` - Document statistics
-
-### Utility (1 tool)
-- `yuque_hello` - Test API connectivity
+| Category | Tool | Description |
+|----------|------|-------------|
+| **User** | `yuque_get_user` | Get current user info |
+| **User** | `yuque_list_groups` | List user's groups/teams |
+| **Search** | `yuque_search` | Search docs, repos, or users |
+| **Repos** | `yuque_list_repos` | List repos for user or group |
+| **Repos** | `yuque_get_repo` | Get repo details |
+| **Repos** | `yuque_create_repo` | Create new repo |
+| **Repos** | `yuque_update_repo` | Update repo settings |
+| **Repos** | `yuque_delete_repo` | Delete repo |
+| **Docs** | `yuque_list_docs` | List documents in repo |
+| **Docs** | `yuque_get_doc` | Get document with full content |
+| **Docs** | `yuque_create_doc` | Create new document |
+| **Docs** | `yuque_update_doc` | Update document |
+| **Docs** | `yuque_delete_doc` | Delete document |
+| **TOC** | `yuque_get_toc` | Get repo table of contents |
+| **TOC** | `yuque_update_toc` | Update repo TOC |
+| **Versions** | `yuque_list_doc_versions` | List document versions |
+| **Versions** | `yuque_get_doc_version` | Get specific version |
+| **Groups** | `yuque_list_group_members` | List group members |
+| **Groups** | `yuque_update_group_member` | Update member role |
+| **Groups** | `yuque_remove_group_member` | Remove member |
+| **Stats** | `yuque_group_stats` | Group statistics |
+| **Stats** | `yuque_group_member_stats` | Member statistics |
+| **Stats** | `yuque_group_book_stats` | Book statistics |
+| **Stats** | `yuque_group_doc_stats` | Document statistics |
+| **Utility** | `yuque_hello` | Test API connectivity |
 
 ## Docker
 
 ```bash
-# Build
 docker build -t yuque-mcp-server .
-
-# Run (stdio mode)
 docker run --rm -i -e YUQUE_TOKEN=your_token yuque-mcp-server
 ```
 
-MCP client configuration with Docker:
+MCP client config with Docker:
 
 ```json
 {
@@ -131,90 +144,65 @@ MCP client configuration with Docker:
 }
 ```
 
-## Configuration
-
-### Environment Variables
-
-- `YUQUE_TOKEN` - Your Yuque API token (required)
-- `PORT` - HTTP server port (default: 3000, HTTP mode only)
-
-### MCP Client Configuration
-
-Add to your MCP client configuration (e.g., Claude Desktop):
-
-```json
-{
-  "mcpServers": {
-    "yuque": {
-      "command": "yuque-mcp-server",
-      "env": {
-        "YUQUE_TOKEN": "your_token_here"
-      }
-    }
-  }
-}
-```
-
 ## Development
 
 ```bash
-# Clone the repository
-git clone https://github.com/yourusername/yuque-mcp-server.git
+git clone https://github.com/chen201724/yuque-mcp-server.git
 cd yuque-mcp-server
-
-# Install dependencies
 npm install
-
-# Run tests
-npm test
-
-# Run with coverage
-npm run test:coverage
-
-# Build
-npm run build
-
-# Development mode with hot reload
-npm run dev
-
-# Lint
-npm run lint
-
-# Format
-npm run format
+npm test              # run tests
+npm run test:coverage # with coverage
+npm run build         # compile TypeScript
+npm run dev           # dev mode with hot reload
+npm run lint          # lint
+npm run format        # format
 ```
 
 ## Architecture
 
 ```
 src/
-├── index.ts              — HTTP server entry
-├── cli.ts                — CLI entry (stdio)
+├── cli.ts                — CLI entry (stdio transport)
+├── index.ts              — HTTP entry (self-hosted, optional)
 ├── server.ts             — MCP server core
-├── tools/                — Tool implementations
-│   ├── user.ts
-│   ├── repo.ts
-│   ├── doc.ts
-│   ├── toc.ts
-│   ├── search.ts
-│   ├── group.ts
-│   ├── stats.ts
-│   └── version.ts
+├── tools/                — Tool implementations (25 tools)
+│   ├── user.ts           — User & group listing
+│   ├── repo.ts           — Repository CRUD
+│   ├── doc.ts            — Document CRUD
+│   ├── toc.ts            — Table of contents
+│   ├── search.ts         — Full-text search
+│   ├── group.ts          — Group member management
+│   ├── stats.ts          — Analytics & statistics
+│   └── version.ts        — Document version history
 ├── services/
-│   ├── yuque-client.ts   — Yuque API client
+│   ├── yuque-client.ts   — Yuque API HTTP client
 │   └── types.ts          — Type definitions
 └── utils/
-    ├── format.ts         — Response formatting
-    └── error.ts          — Error handling
+    ├── format.ts         — AI-optimized response formatting
+    └── error.ts          — Error handling & user-friendly messages
 ```
+
+## Troubleshooting
+
+**"YUQUE_TOKEN is required"**
+Set the token via environment variable or `--token` argument. Get yours at [Yuque Settings](https://www.yuque.com/settings/tokens).
+
+**"Request failed with status 401"**
+Your token is invalid or expired. Generate a new one from Yuque settings.
+
+**"Request failed with status 429"**
+Rate limited by Yuque API. Wait a moment and retry.
+
+**Tool not found**
+Make sure you're using the latest version: `npx -y yuque-mcp-server@latest`
 
 ## Contributing
 
-We welcome contributions! Please see [CONTRIBUTING.md](./CONTRIBUTING.md) for details.
+Contributions welcome! Please see [CONTRIBUTING.md](./CONTRIBUTING.md).
 
 ## Security
 
-For security issues, please see [SECURITY.md](./SECURITY.md).
+For security issues, see [SECURITY.md](./SECURITY.md).
 
 ## License
 
@@ -224,8 +212,4 @@ For security issues, please see [SECURITY.md](./SECURITY.md).
 
 - [Yuque API Documentation](https://www.yuque.com/yuque/developer/api)
 - [Model Context Protocol](https://modelcontextprotocol.io/)
-- [Yuque Official Website](https://www.yuque.com/)
-
-## Acknowledgments
-
-This project is inspired by the [Notion MCP Server](https://github.com/makenotion/notion-mcp-server) and follows Ant Design open-source standards.
+- [MCP TypeScript SDK](https://github.com/modelcontextprotocol/typescript-sdk)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -159,7 +159,7 @@ Docker 方式的 MCP 客户端配置：
 
 ```bash
 # 克隆仓库
-git clone https://github.com/yourusername/yuque-mcp-server.git
+git clone https://github.com/chen201724/yuque-mcp-server.git
 cd yuque-mcp-server
 
 # 安装依赖

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,11 +2,11 @@
 
 ## Reporting a Vulnerability
 
-Please email security issues to [INSERT EMAIL]. Do not open public issues for security vulnerabilities.
+Please open a [security advisory](https://github.com/chen201724/yuque-mcp-server/security/advisories/new) on GitHub. Do not open public issues for security vulnerabilities.
 
 ## Security Best Practices
 
-1. **Protect Your API Token** - Never commit YUQUE_TOKEN to version control
-2. **Use HTTPS** - Always use HTTPS in production
-3. **Keep Dependencies Updated** - Regularly run npm audit
-4. **Follow Least Privilege** - Use appropriate Yuque permissions
+1. **Protect Your API Token** — Never commit `YUQUE_TOKEN` to version control. Use environment variables or a secrets manager.
+2. **Use Read-Only Tokens** — If you only need to read data, generate a read-only token from [Yuque Settings](https://www.yuque.com/settings/tokens).
+3. **Keep Dependencies Updated** — Regularly run `npm audit` and update dependencies.
+4. **Review Tool Permissions** — This server can create, update, and delete content in your Yuque workspace. Understand the scope before granting access.

--- a/package.json
+++ b/package.json
@@ -1,15 +1,22 @@
 {
   "name": "yuque-mcp-server",
   "version": "0.1.0",
-  "description": "Official-quality MCP server for Yuque (语雀) API",
+  "description": "MCP server for Yuque (语雀) — expose Yuque knowledge base to AI assistants via Model Context Protocol",
   "type": "module",
-  "main": "dist/index.js",
+  "main": "dist/cli.js",
   "bin": {
     "yuque-mcp-server": "dist/cli.js"
   },
+  "files": [
+    "dist",
+    "README.md",
+    "README.zh-CN.md",
+    "LICENSE",
+    "CHANGELOG.md"
+  ],
   "scripts": {
     "build": "tsc && chmod +x dist/cli.js",
-    "dev": "tsx watch src/index.ts",
+    "dev": "tsx watch src/cli.ts",
     "test": "vitest",
     "test:coverage": "vitest --coverage",
     "lint": "eslint src tests",
@@ -25,18 +32,20 @@
     "model-context-protocol",
     "ai",
     "llm",
-    "knowledge-base"
+    "knowledge-base",
+    "claude",
+    "cursor"
   ],
-  "author": "Yuque MCP Contributors",
+  "author": "chen201724",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/yourusername/yuque-mcp-server.git"
+    "url": "https://github.com/chen201724/yuque-mcp-server.git"
   },
   "bugs": {
-    "url": "https://github.com/yourusername/yuque-mcp-server/issues"
+    "url": "https://github.com/chen201724/yuque-mcp-server/issues"
   },
-  "homepage": "https://github.com/yourusername/yuque-mcp-server#readme",
+  "homepage": "https://github.com/chen201724/yuque-mcp-server#readme",
   "engines": {
     "node": ">=18.0.0"
   },


### PR DESCRIPTION
## Summary

Fix all pre-release issues: placeholder URLs, incorrect entry point, and rewrite README with proper MCP client configuration examples.

## Changes

### package.json
- `main`: `dist/index.js` → `dist/cli.js` (stdio is the primary entry point)
- `dev` script: points to `cli.ts` instead of `index.ts`
- Added `files` field for clean npm publish (dist, README, LICENSE, CHANGELOG)
- Fixed `repository`, `bugs`, `homepage` URLs (`yourusername` → `chen201724`)
- Updated `author`, added `claude` and `cursor` keywords

### README (full rewrite)
- Claude Code configuration example (front and center)
- Claude Desktop, Cursor config examples
- Tools presented as a scannable table
- Troubleshooting section (common errors and fixes)
- Architecture section updated (cli.ts as primary, index.ts as optional)
- Removed references to HTTP mode as primary usage

### Placeholder Fixes
- `CHANGELOG.md`: fixed URLs, updated release date and content
- `SECURITY.md`: replaced `[INSERT EMAIL]` with GitHub Security Advisory link
- `CODE_OF_CONDUCT.md`: replaced placeholder email with GitHub Issues link
- `README.zh-CN.md`: fixed repository URLs