### PR TITLE
test: unit tests for all 25 MCP tools

### DIFF
--- a/tests/tools/doc.test.ts
+++ b/tests/tools/doc.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { docTools } from '../../src/tools/doc.js';
+import type { YuqueClient } from '../../src/services/yuque-client.js';
+
+const mockClient = {
+  listDocs: vi.fn(),
+  getDoc: vi.fn(),
+  createDoc: vi.fn(),
+  updateDoc: vi.fn(),
+  deleteDoc: vi.fn(),
+} as unknown as YuqueClient;
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('docTools', () => {
+  describe('yuque_list_docs', () => {
+    it('should list docs for a repo', async () => {
+      (mockClient.listDocs as ReturnType<typeof vi.fn>).mockResolvedValue([
+        { id: 1, slug: 'doc1', title: 'Doc 1', format: 'markdown', created_at: '2024-01-01', updated_at: '2024-01-02', word_count: 100 },
+      ]);
+      const result = await docTools.yuque_list_docs.handler(mockClient, { repo_id: 1 } as never);
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed).toHaveLength(1);
+      expect(parsed[0]).toHaveProperty('title', 'Doc 1');
+      expect(mockClient.listDocs).toHaveBeenCalledWith(1);
+    });
+
+    it('should accept namespace string', async () => {
+      (mockClient.listDocs as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+      await docTools.yuque_list_docs.handler(mockClient, { repo_id: 'user/repo' } as never);
+      expect(mockClient.listDocs).toHaveBeenCalledWith('user/repo');
+    });
+  });
+
+  describe('yuque_get_doc', () => {
+    it('should get doc with content', async () => {
+      (mockClient.getDoc as ReturnType<typeof vi.fn>).mockResolvedValue({
+        id: 1, slug: 'doc1', title: 'Doc 1', body: '# Hello', body_html: '<h1>Hello</h1>',
+        format: 'markdown', created_at: '2024-01-01', updated_at: '2024-01-02', word_count: 100,
+      });
+      const result = await docTools.yuque_get_doc.handler(mockClient, { repo_id: 1, doc_id: 1 } as never);
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed).toHaveProperty('body', '# Hello');
+      expect(mockClient.getDoc).toHaveBeenCalledWith(1, 1);
+    });
+  });
+
+  describe('yuque_create_doc', () => {
+    it('should create doc with title and body', async () => {
+      (mockClient.createDoc as ReturnType<typeof vi.fn>).mockResolvedValue({
+        id: 2, slug: 'new-doc', title: 'New Doc', body: 'Content',
+        format: 'markdown', created_at: '2024-01-01', updated_at: '2024-01-01', word_count: 1,
+      });
+      const result = await docTools.yuque_create_doc.handler(mockClient, {
+        repo_id: 1, title: 'New Doc', body: 'Content',
+      } as never);
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed).toHaveProperty('title', 'New Doc');
+      expect(mockClient.createDoc).toHaveBeenCalledWith(1, expect.objectContaining({ title: 'New Doc', body: 'Content' }));
+    });
+  });
+
+  describe('yuque_update_doc', () => {
+    it('should update doc', async () => {
+      (mockClient.updateDoc as ReturnType<typeof vi.fn>).mockResolvedValue({
+        id: 1, slug: 'doc1', title: 'Updated', body: 'New content',
+        format: 'markdown', created_at: '2024-01-01', updated_at: '2024-01-02', word_count: 2,
+      });
+      const result = await docTools.yuque_update_doc.handler(mockClient, {
+        repo_id: 1, doc_id: 1, title: 'Updated',
+      } as never);
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed).toHaveProperty('title', 'Updated');
+    });
+  });
+
+  describe('yuque_delete_doc', () => {
+    it('should delete doc and return success message', async () => {
+      (mockClient.deleteDoc as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
+      const result = await docTools.yuque_delete_doc.handler(mockClient, { repo_id: 1, doc_id: 1 } as never);
+      expect(result.content[0].text).toContain('deleted successfully');
+      expect(mockClient.deleteDoc).toHaveBeenCalledWith(1, 1);
+    });
+  });
+});

--- a/tests/tools/remaining.test.ts
+++ b/tests/tools/remaining.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { searchTools } from '../../src/tools/search.js';
+import { tocTools } from '../../src/tools/toc.js';
+import { groupTools } from '../../src/tools/group.js';
+import { statsTools } from '../../src/tools/stats.js';
+import { versionTools } from '../../src/tools/version.js';
+import type { YuqueClient } from '../../src/services/yuque-client.js';
+
+const mockClient = {
+  search: vi.fn(),
+  getToc: vi.fn(),
+  updateToc: vi.fn(),
+  listGroupMembers: vi.fn(),
+  updateGroupMember: vi.fn(),
+  removeGroupMember: vi.fn(),
+  getGroupStats: vi.fn(),
+  getGroupMemberStats: vi.fn(),
+  getGroupBookStats: vi.fn(),
+  getGroupDocStats: vi.fn(),
+  listDocVersions: vi.fn(),
+  getDocVersion: vi.fn(),
+  hello: vi.fn(),
+} as unknown as YuqueClient;
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('searchTools', () => {
+  describe('yuque_search', () => {
+    it('should search with query', async () => {
+      (mockClient.search as ReturnType<typeof vi.fn>).mockResolvedValue({ items: [{ id: 1, type: 'doc', title: 'Result' }], total: 1 });
+      const result = await searchTools.yuque_search.handler(mockClient, { query: 'test' } as never);
+      expect(result.content[0].type).toBe('text');
+      expect(mockClient.search).toHaveBeenCalledWith('test', undefined);
+    });
+
+    it('should search with type filter', async () => {
+      (mockClient.search as ReturnType<typeof vi.fn>).mockResolvedValue({ items: [], total: 0 });
+      await searchTools.yuque_search.handler(mockClient, { query: 'test', type: 'doc' } as never);
+      expect(mockClient.search).toHaveBeenCalledWith('test', 'doc');
+    });
+  });
+});
+
+describe('tocTools', () => {
+  describe('yuque_get_toc', () => {
+    it('should get toc', async () => {
+      (mockClient.getToc as ReturnType<typeof vi.fn>).mockResolvedValue([
+        { title: 'Ch1', uuid: 'u1', url: '/ch1', prev_uuid: '', sibling_uuid: '', child_uuid: '', parent_uuid: '', doc_id: 1, level: 0, id: 1, open_window: 0, visible: 1 },
+      ]);
+      const result = await tocTools.yuque_get_toc.handler(mockClient, { repo_id: 1 } as never);
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed).toHaveLength(1);
+      expect(parsed[0]).toHaveProperty('title', 'Ch1');
+    });
+  });
+
+  describe('yuque_update_toc', () => {
+    it('should update toc', async () => {
+      (mockClient.updateToc as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+      const result = await tocTools.yuque_update_toc.handler(mockClient, { repo_id: 1, toc: 'new toc' } as never);
+      expect(result.content[0].type).toBe('text');
+    });
+  });
+});
+
+describe('groupTools', () => {
+  describe('yuque_list_group_members', () => {
+    it('should list members', async () => {
+      (mockClient.listGroupMembers as ReturnType<typeof vi.fn>).mockResolvedValue([
+        { id: 1, user: { id: 1, login: 'user1', name: 'User 1' }, role: 1 },
+      ]);
+      const result = await groupTools.yuque_list_group_members.handler(mockClient, { login: 'grp' } as never);
+      expect(result.content[0].type).toBe('text');
+      expect(mockClient.listGroupMembers).toHaveBeenCalledWith('grp');
+    });
+  });
+
+  describe('yuque_update_group_member', () => {
+    it('should update member role', async () => {
+      (mockClient.updateGroupMember as ReturnType<typeof vi.fn>).mockResolvedValue({
+        id: 1, user: { id: 1, login: 'user1', name: 'User 1' }, role: 1,
+      });
+      const result = await groupTools.yuque_update_group_member.handler(mockClient, { login: 'grp', user_id: 1, role: 1 } as never);
+      expect(result.content[0].type).toBe('text');
+    });
+  });
+
+  describe('yuque_remove_group_member', () => {
+    it('should remove member', async () => {
+      (mockClient.removeGroupMember as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
+      const result = await groupTools.yuque_remove_group_member.handler(mockClient, { login: 'grp', user_id: 1 } as never);
+      expect(result.content[0].text).toContain('removed');
+    });
+  });
+});
+
+describe('statsTools', () => {
+  it('yuque_group_stats should return stats', async () => {
+    (mockClient.getGroupStats as ReturnType<typeof vi.fn>).mockResolvedValue({ members: 10, books: 5, docs: 100 });
+    const result = await statsTools.yuque_group_stats.handler(mockClient, { group_login: 'grp' } as never);
+    expect(result.content[0].type).toBe('text');
+  });
+
+  it('yuque_group_member_stats should return stats', async () => {
+    (mockClient.getGroupMemberStats as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+    const result = await statsTools.yuque_group_member_stats.handler(mockClient, { group_login: 'grp' } as never);
+    expect(result.content[0].type).toBe('text');
+  });
+
+  it('yuque_group_book_stats should return stats', async () => {
+    (mockClient.getGroupBookStats as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+    const result = await statsTools.yuque_group_book_stats.handler(mockClient, { group_login: 'grp' } as never);
+    expect(result.content[0].type).toBe('text');
+  });
+
+  it('yuque_group_doc_stats should return stats', async () => {
+    (mockClient.getGroupDocStats as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+    const result = await statsTools.yuque_group_doc_stats.handler(mockClient, { group_login: 'grp' } as never);
+    expect(result.content[0].type).toBe('text');
+  });
+});
+
+describe('versionTools', () => {
+  describe('yuque_list_doc_versions', () => {
+    it('should list versions', async () => {
+      (mockClient.listDocVersions as ReturnType<typeof vi.fn>).mockResolvedValue([
+        { id: 1, slug: 'v1', title: 'Version 1', created_at: '2024-01-01', updated_at: '2024-01-01' },
+      ]);
+      const result = await versionTools.yuque_list_doc_versions.handler(mockClient, { repo_id: 1, doc_id: 1 } as never);
+      expect(result.content[0].type).toBe('text');
+    });
+  });
+
+  describe('yuque_get_doc_version', () => {
+    it('should get specific version', async () => {
+      (mockClient.getDocVersion as ReturnType<typeof vi.fn>).mockResolvedValue({
+        id: 1, slug: 'v1', title: 'Version 1', body: 'Content', created_at: '2024-01-01', updated_at: '2024-01-01',
+      });
+      const result = await versionTools.yuque_get_doc_version.handler(mockClient, { version_id: 1 } as never);
+      expect(result.content[0].type).toBe('text');
+    });
+  });
+
+  describe('yuque_hello', () => {
+    it('should test connectivity', async () => {
+      (mockClient.hello as ReturnType<typeof vi.fn>).mockResolvedValue({ message: 'Hello' });
+      const result = await versionTools.yuque_hello.handler(mockClient, {} as never);
+      expect(JSON.parse(result.content[0].text)).toHaveProperty('message', 'Hello');
+    });
+  });
+});

--- a/tests/tools/repo.test.ts
+++ b/tests/tools/repo.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { repoTools } from '../../src/tools/repo.js';
+import type { YuqueClient } from '../../src/services/yuque-client.js';
+
+const mockClient = {
+  listUserRepos: vi.fn(),
+  listGroupRepos: vi.fn(),
+  getRepo: vi.fn(),
+  createUserRepo: vi.fn(),
+  createGroupRepo: vi.fn(),
+  updateRepo: vi.fn(),
+  deleteRepo: vi.fn(),
+} as unknown as YuqueClient;
+
+beforeEach(() => vi.clearAllMocks());
+
+const mockRepo = { id: 1, slug: 'repo', name: 'Repo', namespace: 'user/repo', description: '', public: 1, items_count: 5 };
+
+describe('repoTools', () => {
+  describe('yuque_list_repos', () => {
+    it('should list user repos', async () => {
+      (mockClient.listUserRepos as ReturnType<typeof vi.fn>).mockResolvedValue([mockRepo]);
+      const result = await repoTools.yuque_list_repos.handler(mockClient, { login: 'user', type: 'user' } as never);
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed).toHaveLength(1);
+      expect(mockClient.listUserRepos).toHaveBeenCalledWith('user');
+    });
+
+    it('should list group repos', async () => {
+      (mockClient.listGroupRepos as ReturnType<typeof vi.fn>).mockResolvedValue([mockRepo]);
+      const result = await repoTools.yuque_list_repos.handler(mockClient, { login: 'grp', type: 'group' } as never);
+      expect(mockClient.listGroupRepos).toHaveBeenCalledWith('grp');
+    });
+  });
+
+  describe('yuque_get_repo', () => {
+    it('should get repo by id', async () => {
+      (mockClient.getRepo as ReturnType<typeof vi.fn>).mockResolvedValue(mockRepo);
+      const result = await repoTools.yuque_get_repo.handler(mockClient, { id_or_namespace: 1 } as never);
+      expect(JSON.parse(result.content[0].text)).toHaveProperty('name', 'Repo');
+    });
+
+    it('should get repo by namespace', async () => {
+      (mockClient.getRepo as ReturnType<typeof vi.fn>).mockResolvedValue(mockRepo);
+      await repoTools.yuque_get_repo.handler(mockClient, { id_or_namespace: 'user/repo' } as never);
+      expect(mockClient.getRepo).toHaveBeenCalledWith('user/repo');
+    });
+  });
+
+  describe('yuque_create_repo', () => {
+    it('should create user repo', async () => {
+      (mockClient.createUserRepo as ReturnType<typeof vi.fn>).mockResolvedValue(mockRepo);
+      await repoTools.yuque_create_repo.handler(mockClient, {
+        login: 'user', type: 'user', name: 'Repo', slug: 'repo',
+      } as never);
+      expect(mockClient.createUserRepo).toHaveBeenCalledWith('user', expect.objectContaining({ name: 'Repo', slug: 'repo' }));
+    });
+
+    it('should create group repo', async () => {
+      (mockClient.createGroupRepo as ReturnType<typeof vi.fn>).mockResolvedValue(mockRepo);
+      await repoTools.yuque_create_repo.handler(mockClient, {
+        login: 'grp', type: 'group', name: 'Repo', slug: 'repo',
+      } as never);
+      expect(mockClient.createGroupRepo).toHaveBeenCalledWith('grp', expect.objectContaining({ name: 'Repo' }));
+    });
+  });
+
+  describe('yuque_update_repo', () => {
+    it('should update repo', async () => {
+      (mockClient.updateRepo as ReturnType<typeof vi.fn>).mockResolvedValue(mockRepo);
+      await repoTools.yuque_update_repo.handler(mockClient, { id_or_namespace: 1, name: 'Updated' } as never);
+      expect(mockClient.updateRepo).toHaveBeenCalledWith(1, expect.objectContaining({ name: 'Updated' }));
+    });
+  });
+
+  describe('yuque_delete_repo', () => {
+    it('should delete repo', async () => {
+      (mockClient.deleteRepo as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
+      const result = await repoTools.yuque_delete_repo.handler(mockClient, { id_or_namespace: 1 } as never);
+      expect(result.content[0].text).toContain('deleted successfully');
+    });
+  });
+});

--- a/tests/tools/user.test.ts
+++ b/tests/tools/user.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { userTools } from '../../src/tools/user.js';
+import type { YuqueClient } from '../../src/services/yuque-client.js';
+
+const mockClient = {
+  getUser: vi.fn(),
+  listGroups: vi.fn(),
+} as unknown as YuqueClient;
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('userTools', () => {
+  describe('yuque_get_user', () => {
+    it('should return formatted user', async () => {
+      (mockClient.getUser as ReturnType<typeof vi.fn>).mockResolvedValue({
+        id: 1, type: 'User', login: 'test', name: 'Test', description: '',
+        avatar_url: '', books_count: 5, followers_count: 10,
+      });
+      const result = await userTools.yuque_get_user.handler(mockClient, {} as never);
+      expect(result.content[0].type).toBe('text');
+      expect(JSON.parse(result.content[0].text)).toHaveProperty('login', 'test');
+      expect(mockClient.getUser).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('yuque_list_groups', () => {
+    it('should return formatted groups', async () => {
+      (mockClient.listGroups as ReturnType<typeof vi.fn>).mockResolvedValue([
+        { id: 1, login: 'grp', name: 'Group', description: '', avatar_url: '', books_count: 3, members_count: 5 },
+      ]);
+      const result = await userTools.yuque_list_groups.handler(mockClient, { user_id: 1 } as never);
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed).toHaveLength(1);
+      expect(parsed[0]).toHaveProperty('login', 'grp');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Add comprehensive unit tests for all 25 MCP tool handlers with mocked YuqueClient.

## Test Coverage

| File | Tools Tested | Tests |
|------|-------------|-------|
| `tests/tools/user.test.ts` | yuque_get_user, yuque_list_groups | 2 |
| `tests/tools/doc.test.ts` | list, get, create, update, delete docs | 6 |
| `tests/tools/repo.test.ts` | list (user/group), get, create (user/group), update, delete | 8 |
| `tests/tools/remaining.test.ts` | search, toc (get/update), group (list/update/remove), stats (4), versions (list/get), hello | 14 |

### Existing tests (unchanged)
| File | Tests |
|------|-------|
| `tests/server.test.ts` | 2 |
| `tests/services/yuque-client.test.ts` | 12 |
| `tests/utils/error.test.ts` | 7 |
| `tests/utils/format.test.ts` | 6 |

**Total: 57 tests, all passing** across 8 test files.

## Approach
- Mock `YuqueClient` methods with `vi.fn()`
- Verify correct client method calls (method name + arguments)
- Verify response format (`content[0].type === 'text'`)
- Verify response content (parsed JSON has expected properties)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for Yuque integration tools across document management, repositories, user operations, search, and version tracking to improve code reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->