### PR TITLE
chore: rename npm package to yuque-mcp

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,8 +108,8 @@ Follow [Conventional Commits](https://www.conventionalcommits.org/):
 Build and run with Docker:
 
 ```bash
-docker build -t yuque-mcp-server .
-docker run --rm -i -e YUQUE_TOKEN=your_token yuque-mcp-server
+docker build -t yuque-mcp .
+docker run --rm -i -e YUQUE_TOKEN=your_token yuque-mcp
 ```
 
 ## Questions?

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Visit [Yuque Developer Settings](https://www.yuque.com/settings/tokens) to gener
 #### Claude Code
 
 ```bash
-claude mcp add yuque -- npx -y yuque-mcp-server --token=YOUR_TOKEN
+claude mcp add yuque -- npx -y yuque-mcp --token=YOUR_TOKEN
 ```
 
 Or add to `~/.claude/claude_desktop_config.json`:
@@ -38,7 +38,7 @@ Or add to `~/.claude/claude_desktop_config.json`:
   "mcpServers": {
     "yuque": {
       "command": "npx",
-      "args": ["-y", "yuque-mcp-server"],
+      "args": ["-y", "yuque-mcp"],
       "env": {
         "YUQUE_TOKEN": "YOUR_TOKEN"
       }
@@ -56,7 +56,7 @@ Add to your Claude Desktop config (`~/Library/Application Support/Claude/claude_
   "mcpServers": {
     "yuque": {
       "command": "npx",
-      "args": ["-y", "yuque-mcp-server"],
+      "args": ["-y", "yuque-mcp"],
       "env": {
         "YUQUE_TOKEN": "YOUR_TOKEN"
       }
@@ -74,7 +74,7 @@ Add to `.cursor/mcp.json` in your project root:
   "mcpServers": {
     "yuque": {
       "command": "npx",
-      "args": ["-y", "yuque-mcp-server"],
+      "args": ["-y", "yuque-mcp"],
       "env": {
         "YUQUE_TOKEN": "YOUR_TOKEN"
       }
@@ -86,9 +86,9 @@ Add to `.cursor/mcp.json` in your project root:
 #### Global Install (alternative)
 
 ```bash
-npm install -g yuque-mcp-server
+npm install -g yuque-mcp
 export YUQUE_TOKEN=your_token_here
-yuque-mcp-server
+yuque-mcp
 ```
 
 ## Available Tools
@@ -124,8 +124,8 @@ yuque-mcp-server
 ## Docker
 
 ```bash
-docker build -t yuque-mcp-server .
-docker run --rm -i -e YUQUE_TOKEN=your_token yuque-mcp-server
+docker build -t yuque-mcp .
+docker run --rm -i -e YUQUE_TOKEN=your_token yuque-mcp
 ```
 
 MCP client config with Docker:
@@ -135,7 +135,7 @@ MCP client config with Docker:
   "mcpServers": {
     "yuque": {
       "command": "docker",
-      "args": ["run", "--rm", "-i", "-e", "YUQUE_TOKEN", "yuque-mcp-server"],
+      "args": ["run", "--rm", "-i", "-e", "YUQUE_TOKEN", "yuque-mcp"],
       "env": {
         "YUQUE_TOKEN": "your_token_here"
       }
@@ -194,7 +194,7 @@ Your token is invalid or expired. Generate a new one from Yuque settings.
 Rate limited by Yuque API. Wait a moment and retry.
 
 **Tool not found**
-Make sure you're using the latest version: `npx -y yuque-mcp-server@latest`
+Make sure you're using the latest version: `npx -y yuque-mcp@latest`
 
 ## Contributing
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -21,13 +21,13 @@
 ## 安装
 
 ```bash
-npm install -g yuque-mcp-server
+npm install -g yuque-mcp
 ```
 
 或直接使用 npx:
 
 ```bash
-npx yuque-mcp-server --token=YOUR_TOKEN
+npx yuque-mcp --token=YOUR_TOKEN
 ```
 
 ## 快速开始
@@ -42,13 +42,13 @@ npx yuque-mcp-server --token=YOUR_TOKEN
 
 ```bash
 export YUQUE_TOKEN=your_token_here
-yuque-mcp-server
+yuque-mcp
 ```
 
 或使用 CLI 参数:
 
 ```bash
-yuque-mcp-server --token=your_token_here
+yuque-mcp --token=your_token_here
 ```
 
 **HTTP 模式（用于测试）：**
@@ -109,10 +109,10 @@ npm start
 
 ```bash
 # 构建镜像
-docker build -t yuque-mcp-server .
+docker build -t yuque-mcp .
 
 # 运行（stdio 模式）
-docker run --rm -i -e YUQUE_TOKEN=your_token yuque-mcp-server
+docker run --rm -i -e YUQUE_TOKEN=your_token yuque-mcp
 ```
 
 Docker 方式的 MCP 客户端配置：
@@ -122,7 +122,7 @@ Docker 方式的 MCP 客户端配置：
   "mcpServers": {
     "yuque": {
       "command": "docker",
-      "args": ["run", "--rm", "-i", "-e", "YUQUE_TOKEN", "yuque-mcp-server"],
+      "args": ["run", "--rm", "-i", "-e", "YUQUE_TOKEN", "yuque-mcp"],
       "env": {
         "YUQUE_TOKEN": "your_token_here"
       }
@@ -146,7 +146,7 @@ Docker 方式的 MCP 客户端配置：
 {
   "mcpServers": {
     "yuque": {
-      "command": "yuque-mcp-server",
+      "command": "yuque-mcp",
       "env": {
         "YUQUE_TOKEN": "your_token_here"
       }

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "yuque-mcp-server",
+  "name": "yuque-mcp",
   "version": "0.1.0",
   "description": "MCP server for Yuque (语雀) — expose Yuque knowledge base to AI assistants via Model Context Protocol",
   "type": "module",
   "main": "dist/cli.js",
   "bin": {
-    "yuque-mcp-server": "dist/cli.js"
+    "yuque-mcp": "dist/cli.js"
   },
   "files": [
     "dist",

--- a/src/server.ts
+++ b/src/server.ts
@@ -18,7 +18,7 @@ export function createServer(token: string) {
   const client = new YuqueClient(token);
   const server = new Server(
     {
-      name: 'yuque-mcp-server',
+      name: 'yuque-mcp',
       version: '0.1.0',
     },
     {


### PR DESCRIPTION
## Summary

Rename npm package from `yuque-mcp-server` (taken on npm, v1.2.0) to `yuque-mcp`.

## Changes

- `package.json`: name and bin entry renamed
- `src/server.ts`: MCP server identifier updated
- All docs: npx/install/docker commands updated to `yuque-mcp`
- GitHub repository name remains `yuque-mcp-server` (no change)

## Usage after publish

```bash
npx yuque-mcp --token=YOUR_TOKEN
# or
npm install -g yuque-mcp
yuque-mcp
```