### PR TITLE
fix: convert Zod schemas to JSON Schema for MCP compatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,20 +1,21 @@
 {
-  "name": "yuque-mcp-server",
+  "name": "yuque-mcp",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "yuque-mcp-server",
+      "name": "yuque-mcp",
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.4",
         "axios": "^1.7.9",
-        "zod": "^3.24.1"
+        "zod": "^3.24.1",
+        "zod-to-json-schema": "^3.25.1"
       },
       "bin": {
-        "yuque-mcp-server": "dist/cli.js"
+        "yuque-mcp": "dist/cli.js"
       },
       "devDependencies": {
         "@types/node": "^22.10.5",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,8 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.4",
     "axios": "^1.7.9",
-    "zod": "^3.24.1"
+    "zod": "^3.24.1",
+    "zod-to-json-schema": "^3.25.1"
   },
   "devDependencies": {
     "@types/node": "^22.10.5",

--- a/src/server.ts
+++ b/src/server.ts
@@ -4,6 +4,7 @@ import {
   CallToolRequestSchema,
   ListToolsRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js';
+import { zodToJsonSchema } from 'zod-to-json-schema';
 import { YuqueClient } from './services/yuque-client.js';
 import { userTools } from './tools/user.js';
 import { repoTools } from './tools/repo.js';
@@ -46,7 +47,7 @@ export function createServer(token: string) {
       tools: Object.entries(allTools).map(([name, tool]) => ({
         name,
         description: tool.description,
-        inputSchema: tool.inputSchema,
+        inputSchema: zodToJsonSchema(tool.inputSchema),
       })),
     };
   });


### PR DESCRIPTION
## Problem

Claude Code / Cursor cannot use yuque-mcp tools. The `inputSchema` in `tools/list` response returns raw Zod object internals instead of standard JSON Schema:

```json
// ❌ Before (broken)
"inputSchema": {"_def":{"unknownKeys":"strip","catchall":{"_def":{"typeName":"ZodNever"}}}}

// ✅ After (fixed)
"inputSchema": {"type":"object","properties":{},"additionalProperties":false}
```

## Fix

- Add `zod-to-json-schema` dependency
- Convert Zod schemas to JSON Schema in `ListToolsRequestSchema` handler

## Critical

This is a **P0 bug** — the npm package (0.1.0) is unusable without this fix. Needs a patch release (0.1.1).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Tool input schemas returned by the list_tools endpoint are now presented in JSON Schema format, improving compatibility and interoperability with external systems consuming the API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->