### PR TITLE
feat: add 6 MCP prompts (skills) for common Yuque workflows

### DIFF
--- a/src/prompts/index.ts
+++ b/src/prompts/index.ts
@@ -1,0 +1,22 @@
+import type { PromptDefinition } from './types.js';
+import { smartSearchPrompt } from './smart-search.js';
+import { meetingNotesPrompt } from './meeting-notes.js';
+import { weeklyReportPrompt } from './weekly-report.js';
+import { techDesignPrompt } from './tech-design.js';
+import { onboardingGuidePrompt } from './onboarding-guide.js';
+import { knowledgeReportPrompt } from './knowledge-report.js';
+
+export type { PromptDefinition, PromptArgument, PromptMessage } from './types.js';
+
+export const allPrompts: PromptDefinition[] = [
+  smartSearchPrompt,
+  meetingNotesPrompt,
+  weeklyReportPrompt,
+  techDesignPrompt,
+  onboardingGuidePrompt,
+  knowledgeReportPrompt,
+];
+
+export const promptsByName: Record<string, PromptDefinition> = Object.fromEntries(
+  allPrompts.map((p) => [p.name, p])
+);

--- a/src/prompts/knowledge-report.ts
+++ b/src/prompts/knowledge-report.ts
@@ -1,0 +1,77 @@
+import type { PromptDefinition } from './types.js';
+
+export const knowledgeReportPrompt: PromptDefinition = {
+  name: 'knowledge-report',
+  description: '团队知识月报 — 全面分析团队知识管理数据并生成月报',
+  arguments: [
+    {
+      name: 'login',
+      description: '团队 login 名称',
+      required: true,
+    },
+    {
+      name: 'repo_id',
+      description: '月报存放的知识库 ID 或命名空间',
+      required: true,
+    },
+  ],
+  getMessages: (args: Record<string, string>) => [
+    {
+      role: 'user' as const,
+      content: {
+        type: 'text' as const,
+        text: `请为团队「${args.login}」生成本月知识管理月报，并保存到语雀知识库。
+
+## 操作步骤
+
+1. **获取团队总览数据**：使用 yuque_group_stats 工具，参数 login 为「${args.login}」，获取团队整体统计数据。
+2. **获取成员统计**：使用 yuque_group_member_stats 工具，参数 login 为「${args.login}」，获取成员活跃度和贡献数据。
+3. **获取知识库统计**：使用 yuque_group_book_stats 工具，参数 login 为「${args.login}」，获取各知识库的使用情况。
+4. **获取文档统计**：使用 yuque_group_doc_stats 工具，参数 login 为「${args.login}」，获取文档创建和更新数据。
+
+5. **生成月报**：基于以上全面数据，生成结构化的知识管理月报，包含：
+
+   - 📊 **月度概览**
+     - 关键指标摘要（文档总数、新增数、活跃成员数等）
+     - 与上月对比的增长率
+
+   - 👥 **成员贡献分析**
+     - 活跃成员排行榜（Top 10）
+     - 新增贡献者
+     - 成员活跃度分布
+
+   - 📚 **知识库分析**
+     - 各知识库文档数量和增长
+     - 最活跃的知识库 Top 5
+     - 知识库健康度评估
+
+   - 📝 **文档分析**
+     - 本月新增文档列表
+     - 热门文档（阅读量/点赞最多）
+     - 文档更新频率分析
+
+   - 📈 **趋势与洞察**
+     - 知识沉淀趋势图（文字描述）
+     - 团队知识管理成熟度评估
+     - 值得关注的亮点和问题
+
+   - 🎯 **改进建议**
+     - 基于数据的具体改进建议
+     - 下月重点关注方向
+
+6. **创建文档**：使用 yuque_create_doc 工具，将月报保存到知识库 \`${args.repo_id}\` 中。
+   - title：「知识管理月报 - YYYY年MM月 - ${args.login}」
+   - body：生成的月报 markdown 内容
+   - format：设为 "markdown"
+
+输出格式要求：
+- 数据驱动，所有结论都要有数据支撑
+- 使用表格展示排名和对比数据
+- 趋势用箭头符号标注（📈 📉 ➡️）
+- 建议要具体可执行，避免空泛
+- 语言专业但易读
+- 创建成功后告知文档标题和链接`,
+      },
+    },
+  ],
+};

--- a/src/prompts/meeting-notes.ts
+++ b/src/prompts/meeting-notes.ts
@@ -1,0 +1,52 @@
+import type { PromptDefinition } from './types.js';
+
+export const meetingNotesPrompt: PromptDefinition = {
+  name: 'meeting-notes',
+  description: '会议纪要归档 — 整理会议内容并归档到语雀知识库',
+  arguments: [
+    {
+      name: 'content',
+      description: '会议内容（原始记录或要点）',
+      required: true,
+    },
+    {
+      name: 'repo_id',
+      description: '目标知识库 ID 或命名空间（如 "mygroup/meeting-notes"）',
+      required: true,
+    },
+  ],
+  getMessages: (args: Record<string, string>) => [
+    {
+      role: 'user' as const,
+      content: {
+        type: 'text' as const,
+        text: `请将以下会议内容整理为标准会议纪要，并归档到语雀知识库。
+
+## 原始会议内容
+${args.content}
+
+## 操作步骤
+
+1. **整理格式**：将上述会议内容整理为标准会议纪要格式，包含以下部分：
+   - 📅 会议基本信息（日期、时间、地点/方式）
+   - 👥 参会人员
+   - 📋 会议议题
+   - 💬 讨论要点（按议题分类）
+   - ✅ 决议事项
+   - 📌 待办事项（明确责任人和截止日期）
+   - 📝 备注
+
+2. **创建文档**：使用 yuque_create_doc 工具，将整理好的会议纪要创建到知识库 \`${args.repo_id}\` 中。
+   - title：使用格式「会议纪要 - YYYY-MM-DD - 主题」
+   - body：整理好的 markdown 内容
+   - format：设为 "markdown"
+
+输出格式要求：
+- 使用 Markdown 格式
+- 待办事项使用 checkbox 格式（- [ ]）
+- 语言简洁专业
+- 创建成功后告知文档标题和链接`,
+      },
+    },
+  ],
+};

--- a/src/prompts/onboarding-guide.ts
+++ b/src/prompts/onboarding-guide.ts
@@ -1,0 +1,60 @@
+import type { PromptDefinition } from './types.js';
+
+export const onboardingGuidePrompt: PromptDefinition = {
+  name: 'onboarding-guide',
+  description: '新人入职知识包 — 自动整理团队核心文档生成入职阅读指南',
+  arguments: [
+    {
+      name: 'login',
+      description: '团队 login 名称',
+      required: true,
+    },
+    {
+      name: 'repo_id',
+      description: '入职指南存放的知识库 ID 或命名空间',
+      required: true,
+    },
+  ],
+  getMessages: (args: Record<string, string>) => [
+    {
+      role: 'user' as const,
+      content: {
+        type: 'text' as const,
+        text: `请为团队「${args.login}」整理一份新人入职知识包，并保存到语雀知识库。
+
+## 操作步骤
+
+1. **获取团队知识库列表**：使用 yuque_list_repos 工具，参数 login 为「${args.login}」，type 为 "group"，列出团队所有知识库。
+2. **获取各库目录**：对每个知识库，使用 yuque_get_toc 工具获取目录结构，了解文档组织方式。
+3. **筛选核心文档**：从目录中筛选出新人必读的核心文档，重点关注：
+   - 团队介绍 / 组织架构
+   - 开发规范 / 编码规范
+   - 环境搭建 / 工具配置
+   - 产品文档 / 业务介绍
+   - 流程规范（发布流程、代码审查等）
+   - FAQ / 常见问题
+
+4. **生成入职指南**：整理为结构化的入职阅读指南，包含：
+   - 🎯 阅读指南说明（预计阅读时间、建议顺序）
+   - 📚 必读文档清单（按优先级排序，附文档链接）
+     - 第一周必读
+     - 第二周推荐
+     - 进阶阅读
+   - 🗺️ 知识库导航（各知识库简介和用途）
+   - 💡 新人 Tips（常见问题和建议）
+
+5. **创建文档**：使用 yuque_create_doc 工具，将入职指南保存到知识库 \`${args.repo_id}\` 中。
+   - title：「新人入职知识包 - ${args.login} 团队」
+   - body：生成的入职指南 markdown 内容
+   - format：设为 "markdown"
+
+输出格式要求：
+- 文档链接使用语雀的文档路径格式
+- 每篇推荐文档附简短说明（1-2 句话）
+- 按阅读优先级分层，避免信息过载
+- 语气友好、鼓励性，适合新人阅读
+- 创建成功后告知文档标题和链接`,
+      },
+    },
+  ],
+};

--- a/src/prompts/smart-search.ts
+++ b/src/prompts/smart-search.ts
@@ -1,0 +1,35 @@
+import type { PromptDefinition } from './types.js';
+
+export const smartSearchPrompt: PromptDefinition = {
+  name: 'smart-search',
+  description: '智能搜索与问答 — 用自然语言搜索语雀文档并总结要点',
+  arguments: [
+    {
+      name: 'query',
+      description: '搜索关键词或问题',
+      required: true,
+    },
+  ],
+  getMessages: (args: Record<string, string>) => [
+    {
+      role: 'user' as const,
+      content: {
+        type: 'text' as const,
+        text: `请帮我在语雀中搜索并回答以下问题：「${args.query}」
+
+请按照以下步骤操作：
+
+1. **搜索文档**：使用 yuque_search 工具，搜索关键词「${args.query}」，type 设为 "doc"。
+2. **筛选结果**：从搜索结果中挑选最相关的 1-3 篇文档。
+3. **读取内容**：对每篇相关文档，使用 yuque_get_doc 工具获取完整内容。
+4. **总结回答**：基于文档内容，用清晰的结构化格式回答用户的问题。
+
+输出格式要求：
+- 先给出简明的直接回答
+- 然后列出关键要点（使用 bullet points）
+- 最后附上参考文档的标题和链接
+- 如果搜索结果中没有找到相关内容，请如实告知`,
+      },
+    },
+  ],
+};

--- a/src/prompts/tech-design.ts
+++ b/src/prompts/tech-design.ts
@@ -1,0 +1,69 @@
+import type { PromptDefinition } from './types.js';
+
+export const techDesignPrompt: PromptDefinition = {
+  name: 'tech-design',
+  description: '技术方案撰写 — 按标准模板生成技术方案文档',
+  arguments: [
+    {
+      name: 'title',
+      description: '技术方案标题',
+      required: true,
+    },
+    {
+      name: 'requirements',
+      description: '需求描述',
+      required: true,
+    },
+    {
+      name: 'repo_id',
+      description: '目标知识库 ID 或命名空间',
+      required: true,
+    },
+  ],
+  getMessages: (args: Record<string, string>) => [
+    {
+      role: 'user' as const,
+      content: {
+        type: 'text' as const,
+        text: `请为以下需求撰写技术方案文档，并保存到语雀知识库。
+
+## 方案标题
+${args.title}
+
+## 需求描述
+${args.requirements}
+
+## 操作步骤
+
+1. **撰写技术方案**：按照以下标准模板生成完整的技术方案文档：
+
+   ### 文档结构
+   - **1. 背景与现状**：描述当前状况和面临的问题
+   - **2. 目标与范围**：明确本方案要达成的目标和边界
+   - **3. 方案设计**
+     - 3.1 整体架构：系统架构图和模块划分
+     - 3.2 核心流程：关键业务流程描述
+     - 3.3 数据模型：核心数据结构设计
+     - 3.4 接口设计：关键 API 接口定义
+   - **4. 技术选型**：技术栈选择及理由
+   - **5. 排期计划**：里程碑和时间节点
+   - **6. 风险评估**：潜在风险和应对措施
+   - **7. 参考资料**：相关文档和链接
+
+2. **创建文档**：使用 yuque_create_doc 工具，将技术方案保存到知识库 \`${args.repo_id}\` 中。
+   - title：「技术方案 - ${args.title}」
+   - body：生成的技术方案 markdown 内容
+   - format：设为 "markdown"
+
+输出格式要求：
+- 使用 Markdown 格式，层级清晰
+- 架构部分可以用文字描述或 ASCII 图
+- 接口设计使用代码块展示
+- 排期使用表格格式
+- 风险评估标注严重程度（高/中/低）
+- 内容要专业、具体，避免空泛描述
+- 创建成功后告知文档标题和链接`,
+      },
+    },
+  ],
+};

--- a/src/prompts/types.ts
+++ b/src/prompts/types.ts
@@ -1,0 +1,20 @@
+export interface PromptArgument {
+  name: string;
+  description?: string;
+  required?: boolean;
+}
+
+export interface PromptMessage {
+  role: 'user' | 'assistant';
+  content: {
+    type: 'text';
+    text: string;
+  };
+}
+
+export interface PromptDefinition {
+  name: string;
+  description: string;
+  arguments: PromptArgument[];
+  getMessages: (args: Record<string, string>) => PromptMessage[];
+}

--- a/src/prompts/weekly-report.ts
+++ b/src/prompts/weekly-report.ts
@@ -1,0 +1,49 @@
+import type { PromptDefinition } from './types.js';
+
+export const weeklyReportPrompt: PromptDefinition = {
+  name: 'weekly-report',
+  description: '周报生成 — 基于团队本周数据自动生成周报',
+  arguments: [
+    {
+      name: 'login',
+      description: '团队 login 名称',
+      required: true,
+    },
+    {
+      name: 'repo_id',
+      description: '周报存放的知识库 ID 或命名空间',
+      required: true,
+    },
+  ],
+  getMessages: (args: Record<string, string>) => [
+    {
+      role: 'user' as const,
+      content: {
+        type: 'text' as const,
+        text: `请为团队「${args.login}」生成本周周报，并保存到语雀知识库。
+
+## 操作步骤
+
+1. **获取文档统计**：使用 yuque_group_doc_stats 工具，参数 login 为「${args.login}」，获取本周文档创建和更新数据。
+2. **获取成员统计**：使用 yuque_group_member_stats 工具，参数 login 为「${args.login}」，获取成员活跃度数据。
+3. **生成周报**：基于以上数据，生成结构化周报，包含以下部分：
+   - 📊 本周概览（关键数字摘要）
+   - 📝 文档动态（新增文档、更新文档、热门文档）
+   - 👥 成员贡献（活跃成员排名、贡献亮点）
+   - 📈 趋势分析（与上周对比，增长或下降趋势）
+   - 🎯 下周建议（基于数据给出改进建议）
+
+4. **创建文档**：使用 yuque_create_doc 工具，将周报保存到知识库 \`${args.repo_id}\` 中。
+   - title：使用格式「周报 - YYYY年第N周（MM.DD - MM.DD）」
+   - body：生成的周报 markdown 内容
+   - format：设为 "markdown"
+
+输出格式要求：
+- 数据要有具体数字，避免模糊描述
+- 使用表格展示排名数据
+- 趋势用箭头符号标注（📈 📉 ➡️）
+- 创建成功后告知文档标题和链接`,
+      },
+    },
+  ],
+};

--- a/tests/prompts.test.ts
+++ b/tests/prompts.test.ts
@@ -1,0 +1,202 @@
+import { describe, it, expect } from 'vitest';
+import { allPrompts, promptsByName } from '../src/prompts/index.js';
+import type { PromptDefinition } from '../src/prompts/types.js';
+
+describe('prompts', () => {
+  const expectedPromptNames = [
+    'smart-search',
+    'meeting-notes',
+    'weekly-report',
+    'tech-design',
+    'onboarding-guide',
+    'knowledge-report',
+  ];
+
+  describe('allPrompts', () => {
+    it('should export exactly 6 prompts', () => {
+      expect(allPrompts).toHaveLength(6);
+    });
+
+    it('should contain all expected prompt names', () => {
+      const names = allPrompts.map((p) => p.name);
+      expect(names).toEqual(expectedPromptNames);
+    });
+
+    it('should have valid structure for each prompt', () => {
+      for (const prompt of allPrompts) {
+        expect(prompt.name).toBeTruthy();
+        expect(prompt.description).toBeTruthy();
+        expect(Array.isArray(prompt.arguments)).toBe(true);
+        expect(typeof prompt.getMessages).toBe('function');
+      }
+    });
+  });
+
+  describe('promptsByName', () => {
+    it('should have entries for all 6 prompts', () => {
+      expect(Object.keys(promptsByName)).toHaveLength(6);
+      for (const name of expectedPromptNames) {
+        expect(promptsByName[name]).toBeDefined();
+      }
+    });
+  });
+
+  describe('smart-search', () => {
+    let prompt: PromptDefinition;
+
+    it('should have correct metadata', () => {
+      prompt = promptsByName['smart-search'];
+      expect(prompt.name).toBe('smart-search');
+      expect(prompt.arguments).toHaveLength(1);
+      expect(prompt.arguments[0].name).toBe('query');
+      expect(prompt.arguments[0].required).toBe(true);
+    });
+
+    it('should generate messages with query interpolated', () => {
+      prompt = promptsByName['smart-search'];
+      const messages = prompt.getMessages({ query: 'API 设计规范' });
+      expect(messages).toHaveLength(1);
+      expect(messages[0].role).toBe('user');
+      expect(messages[0].content.type).toBe('text');
+      expect(messages[0].content.text).toContain('API 设计规范');
+      expect(messages[0].content.text).toContain('yuque_search');
+      expect(messages[0].content.text).toContain('yuque_get_doc');
+    });
+  });
+
+  describe('meeting-notes', () => {
+    let prompt: PromptDefinition;
+
+    it('should have correct metadata', () => {
+      prompt = promptsByName['meeting-notes'];
+      expect(prompt.name).toBe('meeting-notes');
+      expect(prompt.arguments).toHaveLength(2);
+      expect(prompt.arguments[0].name).toBe('content');
+      expect(prompt.arguments[0].required).toBe(true);
+      expect(prompt.arguments[1].name).toBe('repo_id');
+      expect(prompt.arguments[1].required).toBe(true);
+    });
+
+    it('should generate messages with content and repo_id interpolated', () => {
+      prompt = promptsByName['meeting-notes'];
+      const messages = prompt.getMessages({
+        content: '讨论了新功能上线计划',
+        repo_id: 'team/meetings',
+      });
+      expect(messages).toHaveLength(1);
+      expect(messages[0].content.text).toContain('讨论了新功能上线计划');
+      expect(messages[0].content.text).toContain('team/meetings');
+      expect(messages[0].content.text).toContain('yuque_create_doc');
+    });
+  });
+
+  describe('weekly-report', () => {
+    let prompt: PromptDefinition;
+
+    it('should have correct metadata', () => {
+      prompt = promptsByName['weekly-report'];
+      expect(prompt.name).toBe('weekly-report');
+      expect(prompt.arguments).toHaveLength(2);
+      expect(prompt.arguments[0].name).toBe('login');
+      expect(prompt.arguments[0].required).toBe(true);
+      expect(prompt.arguments[1].name).toBe('repo_id');
+      expect(prompt.arguments[1].required).toBe(true);
+    });
+
+    it('should generate messages with login and repo_id interpolated', () => {
+      prompt = promptsByName['weekly-report'];
+      const messages = prompt.getMessages({
+        login: 'my-team',
+        repo_id: 'my-team/weekly',
+      });
+      expect(messages).toHaveLength(1);
+      expect(messages[0].content.text).toContain('my-team');
+      expect(messages[0].content.text).toContain('my-team/weekly');
+      expect(messages[0].content.text).toContain('yuque_group_doc_stats');
+      expect(messages[0].content.text).toContain('yuque_group_member_stats');
+      expect(messages[0].content.text).toContain('yuque_create_doc');
+    });
+  });
+
+  describe('tech-design', () => {
+    let prompt: PromptDefinition;
+
+    it('should have correct metadata', () => {
+      prompt = promptsByName['tech-design'];
+      expect(prompt.name).toBe('tech-design');
+      expect(prompt.arguments).toHaveLength(3);
+      expect(prompt.arguments[0].name).toBe('title');
+      expect(prompt.arguments[1].name).toBe('requirements');
+      expect(prompt.arguments[2].name).toBe('repo_id');
+      for (const arg of prompt.arguments) {
+        expect(arg.required).toBe(true);
+      }
+    });
+
+    it('should generate messages with all args interpolated', () => {
+      prompt = promptsByName['tech-design'];
+      const messages = prompt.getMessages({
+        title: '用户权限系统',
+        requirements: '实现 RBAC 权限模型',
+        repo_id: 'team/designs',
+      });
+      expect(messages).toHaveLength(1);
+      expect(messages[0].content.text).toContain('用户权限系统');
+      expect(messages[0].content.text).toContain('实现 RBAC 权限模型');
+      expect(messages[0].content.text).toContain('team/designs');
+      expect(messages[0].content.text).toContain('yuque_create_doc');
+    });
+  });
+
+  describe('onboarding-guide', () => {
+    let prompt: PromptDefinition;
+
+    it('should have correct metadata', () => {
+      prompt = promptsByName['onboarding-guide'];
+      expect(prompt.name).toBe('onboarding-guide');
+      expect(prompt.arguments).toHaveLength(2);
+      expect(prompt.arguments[0].name).toBe('login');
+      expect(prompt.arguments[1].name).toBe('repo_id');
+    });
+
+    it('should generate messages referencing correct tools', () => {
+      prompt = promptsByName['onboarding-guide'];
+      const messages = prompt.getMessages({
+        login: 'dev-team',
+        repo_id: 'dev-team/onboarding',
+      });
+      expect(messages).toHaveLength(1);
+      expect(messages[0].content.text).toContain('dev-team');
+      expect(messages[0].content.text).toContain('yuque_list_repos');
+      expect(messages[0].content.text).toContain('yuque_get_toc');
+      expect(messages[0].content.text).toContain('yuque_create_doc');
+    });
+  });
+
+  describe('knowledge-report', () => {
+    let prompt: PromptDefinition;
+
+    it('should have correct metadata', () => {
+      prompt = promptsByName['knowledge-report'];
+      expect(prompt.name).toBe('knowledge-report');
+      expect(prompt.arguments).toHaveLength(2);
+      expect(prompt.arguments[0].name).toBe('login');
+      expect(prompt.arguments[1].name).toBe('repo_id');
+    });
+
+    it('should generate messages referencing all stats tools', () => {
+      prompt = promptsByName['knowledge-report'];
+      const messages = prompt.getMessages({
+        login: 'org-team',
+        repo_id: 'org-team/reports',
+      });
+      expect(messages).toHaveLength(1);
+      expect(messages[0].content.text).toContain('org-team');
+      expect(messages[0].content.text).toContain('yuque_group_stats');
+      expect(messages[0].content.text).toContain('yuque_group_member_stats');
+      expect(messages[0].content.text).toContain('yuque_group_book_stats');
+      expect(messages[0].content.text).toContain('yuque_group_doc_stats');
+      expect(messages[0].content.text).toContain('yuque_create_doc');
+    });
+  });
+});


### PR DESCRIPTION
## 概述

为 yuque-mcp-server 添加 MCP Prompts 支持，实现 6 个标准化的 prompt 模板（Skills），覆盖常见的语雀知识管理工作流。

## 实现的 Prompts

| Prompt | 描述 | 参数 |
|--------|------|------|
| `smart-search` | 智能搜索与问答 | `query` |
| `meeting-notes` | 会议纪要归档 | `content`, `repo_id` |
| `weekly-report` | 周报生成 | `login`, `repo_id` |
| `tech-design` | 技术方案撰写 | `title`, `requirements`, `repo_id` |
| `onboarding-guide` | 新人入职知识包 | `login`, `repo_id` |
| `knowledge-report` | 团队知识月报 | `login`, `repo_id` |

## 改动内容

- 新增 `src/prompts/` 目录，包含类型定义、6 个 prompt 文件和汇总导出
- 修改 `src/server.ts`：添加 `prompts` capability，注册 `ListPromptsRequestSchema` 和 `GetPromptRequestSchema` handler
- 新增 `tests/prompts.test.ts`：16 个测试用例，覆盖元数据、消息生成、参数插值

## 测试结果

- 全部 73 个测试通过（16 新增 + 57 已有）
- TypeScript 编译通过
- 新增代码 lint 通过（已有的 lint 问题不在本 PR 范围内）

## 向后兼容

- 不修改任何现有 tools 代码
- 不破坏现有功能
- 所有已有测试继续通过

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced six new prompt templates: Smart Search, Meeting Notes, Weekly Report, Tech Design, Onboarding Guide, and Knowledge Report.
  * Prompts are now accessible via the server API with dynamic message generation based on user inputs.

* **Tests**
  * Added comprehensive test coverage for prompt module functionality and message generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->