### PR TITLE
refactor: code polish and quality improvements

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -20,7 +20,7 @@ export function createServer(token: string) {
   const server = new Server(
     {
       name: 'yuque-mcp',
-      version: '0.1.0',
+      version: '0.1.2',
     },
     {
       capabilities: {

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -147,3 +147,37 @@ export interface YuqueApiError {
   message: string;
   status?: number;
 }
+
+/** Data for creating a repo/book. */
+export interface CreateRepoData {
+  name: string;
+  slug: string;
+  description?: string;
+  public?: number;
+  type?: string;
+}
+
+/** Data for updating a repo/book. */
+export interface UpdateRepoData {
+  name?: string;
+  slug?: string;
+  description?: string;
+  public?: number;
+}
+
+/** Data for creating a document. */
+export interface CreateDocData {
+  title: string;
+  slug?: string;
+  body?: string;
+  format?: string;
+  public?: number;
+}
+
+/** Data for updating a document. */
+export interface UpdateDocData {
+  title?: string;
+  slug?: string;
+  body?: string;
+  public?: number;
+}

--- a/src/services/yuque-client.ts
+++ b/src/services/yuque-client.ts
@@ -10,8 +10,24 @@ import type {
   YuqueGroupMember,
   YuqueStatistics,
   YuqueApiResponse,
+  CreateRepoData,
+  UpdateRepoData,
+  CreateDocData,
+  UpdateDocData,
 } from './types.js';
 import { handleYuqueError } from '../utils/error.js';
+
+/**
+ * Wraps an async operation with standardized Yuque error handling.
+ * Every API call goes through this so error handling stays consistent.
+ */
+async function withErrorHandling<T>(fn: () => Promise<T>): Promise<T> {
+  try {
+    return await fn();
+  } catch (error) {
+    handleYuqueError(error);
+  }
+}
 
 export class YuqueClient {
   private client: AxiosInstance;
@@ -26,334 +42,238 @@ export class YuqueClient {
     });
   }
 
-  // User APIs
+  // ── User APIs ──────────────────────────────────────────────
+
+  /** Get the currently authenticated user. */
   async getUser(): Promise<YuqueUser> {
-    try {
-      const response = await this.client.get<YuqueApiResponse<YuqueUser>>('/user');
-      return response.data.data;
-    } catch (error) {
-      handleYuqueError(error);
-    }
+    return withErrorHandling(async () => {
+      const r = await this.client.get<YuqueApiResponse<YuqueUser>>('/user');
+      return r.data.data;
+    });
   }
 
+  /** List groups/teams that a user belongs to. */
   async listGroups(userId: number): Promise<YuqueGroup[]> {
-    try {
-      const response = await this.client.get<YuqueApiResponse<YuqueGroup[]>>(
-        `/users/${userId}/groups`
-      );
-      return response.data.data;
-    } catch (error) {
-      handleYuqueError(error);
-    }
+    return withErrorHandling(async () => {
+      const r = await this.client.get<YuqueApiResponse<YuqueGroup[]>>(`/users/${userId}/groups`);
+      return r.data.data;
+    });
   }
 
-  // Search API
+  // ── Search API ─────────────────────────────────────────────
+
+  /** Search for documents, repos, or users. */
   async search(query: string, type?: string): Promise<YuqueSearchResult> {
-    try {
+    return withErrorHandling(async () => {
       const params: { q: string; type?: string } = { q: query };
       if (type) params.type = type;
-      const response = await this.client.get<YuqueApiResponse<YuqueSearchResult>>('/search', {
-        params,
-      });
-      return response.data.data;
-    } catch (error) {
-      handleYuqueError(error);
-    }
+      const r = await this.client.get<YuqueApiResponse<YuqueSearchResult>>('/search', { params });
+      return r.data.data;
+    });
   }
 
-  // Repo APIs
+  // ── Repo APIs ──────────────────────────────────────────────
+
+  /** List all repos for a user. */
   async listUserRepos(login: string): Promise<YuqueRepo[]> {
-    try {
-      const response = await this.client.get<YuqueApiResponse<YuqueRepo[]>>(
-        `/users/${login}/repos`
-      );
-      return response.data.data;
-    } catch (error) {
-      handleYuqueError(error);
-    }
+    return withErrorHandling(async () => {
+      const r = await this.client.get<YuqueApiResponse<YuqueRepo[]>>(`/users/${login}/repos`);
+      return r.data.data;
+    });
   }
 
+  /** List all repos for a group. */
   async listGroupRepos(login: string): Promise<YuqueRepo[]> {
-    try {
-      const response = await this.client.get<YuqueApiResponse<YuqueRepo[]>>(
-        `/groups/${login}/repos`
-      );
-      return response.data.data;
-    } catch (error) {
-      handleYuqueError(error);
-    }
+    return withErrorHandling(async () => {
+      const r = await this.client.get<YuqueApiResponse<YuqueRepo[]>>(`/groups/${login}/repos`);
+      return r.data.data;
+    });
   }
 
+  /** Get a repo by ID or namespace (e.g. "group/book"). */
   async getRepo(idOrNamespace: string | number): Promise<YuqueRepo> {
-    try {
-      const response = await this.client.get<YuqueApiResponse<YuqueRepo>>(
-        `/repos/${idOrNamespace}`
-      );
-      return response.data.data;
-    } catch (error) {
-      handleYuqueError(error);
-    }
+    return withErrorHandling(async () => {
+      const r = await this.client.get<YuqueApiResponse<YuqueRepo>>(`/repos/${idOrNamespace}`);
+      return r.data.data;
+    });
   }
 
-  async createUserRepo(login: string, data: {
-    name: string;
-    slug: string;
-    description?: string;
-    public?: number;
-    type?: string;
-  }): Promise<YuqueRepo> {
-    try {
-      const response = await this.client.post<YuqueApiResponse<YuqueRepo>>(
-        `/users/${login}/repos`,
-        data
-      );
-      return response.data.data;
-    } catch (error) {
-      handleYuqueError(error);
-    }
+  /** Create a new repo under a user. */
+  async createUserRepo(login: string, data: CreateRepoData): Promise<YuqueRepo> {
+    return withErrorHandling(async () => {
+      const r = await this.client.post<YuqueApiResponse<YuqueRepo>>(`/users/${login}/repos`, data);
+      return r.data.data;
+    });
   }
 
-  async createGroupRepo(login: string, data: {
-    name: string;
-    slug: string;
-    description?: string;
-    public?: number;
-    type?: string;
-  }): Promise<YuqueRepo> {
-    try {
-      const response = await this.client.post<YuqueApiResponse<YuqueRepo>>(
-        `/groups/${login}/repos`,
-        data
-      );
-      return response.data.data;
-    } catch (error) {
-      handleYuqueError(error);
-    }
+  /** Create a new repo under a group. */
+  async createGroupRepo(login: string, data: CreateRepoData): Promise<YuqueRepo> {
+    return withErrorHandling(async () => {
+      const r = await this.client.post<YuqueApiResponse<YuqueRepo>>(`/groups/${login}/repos`, data);
+      return r.data.data;
+    });
   }
 
-  async updateRepo(idOrNamespace: string | number, data: {
-    name?: string;
-    slug?: string;
-    description?: string;
-    public?: number;
-  }): Promise<YuqueRepo> {
-    try {
-      const response = await this.client.put<YuqueApiResponse<YuqueRepo>>(
-        `/repos/${idOrNamespace}`,
-        data
-      );
-      return response.data.data;
-    } catch (error) {
-      handleYuqueError(error);
-    }
+  /** Update a repo by ID or namespace. */
+  async updateRepo(idOrNamespace: string | number, data: UpdateRepoData): Promise<YuqueRepo> {
+    return withErrorHandling(async () => {
+      const r = await this.client.put<YuqueApiResponse<YuqueRepo>>(`/repos/${idOrNamespace}`, data);
+      return r.data.data;
+    });
   }
 
+  /** Delete a repo by ID or namespace. */
   async deleteRepo(idOrNamespace: string | number): Promise<void> {
-    try {
+    return withErrorHandling(async () => {
       await this.client.delete(`/repos/${idOrNamespace}`);
-    } catch (error) {
-      handleYuqueError(error);
-    }
+    });
   }
 
-  // Doc APIs
+  // ── Doc APIs ───────────────────────────────────────────────
+
+  /** List all documents in a repo. */
   async listDocs(repoId: string | number): Promise<YuqueDoc[]> {
-    try {
-      const response = await this.client.get<YuqueApiResponse<YuqueDoc[]>>(
-        `/repos/${repoId}/docs`
-      );
-      return response.data.data;
-    } catch (error) {
-      handleYuqueError(error);
-    }
+    return withErrorHandling(async () => {
+      const r = await this.client.get<YuqueApiResponse<YuqueDoc[]>>(`/repos/${repoId}/docs`);
+      return r.data.data;
+    });
   }
 
+  /** Get a single document by repo and doc ID/slug. */
   async getDoc(repoId: string | number, docId: string | number): Promise<YuqueDoc> {
-    try {
-      const response = await this.client.get<YuqueApiResponse<YuqueDoc>>(
-        `/repos/${repoId}/docs/${docId}`
-      );
-      return response.data.data;
-    } catch (error) {
-      handleYuqueError(error);
-    }
+    return withErrorHandling(async () => {
+      const r = await this.client.get<YuqueApiResponse<YuqueDoc>>(`/repos/${repoId}/docs/${docId}`);
+      return r.data.data;
+    });
   }
 
-  async createDoc(repoId: string | number, data: {
-    title: string;
-    slug?: string;
-    body?: string;
-    format?: string;
-    public?: number;
-  }): Promise<YuqueDoc> {
-    try {
-      const response = await this.client.post<YuqueApiResponse<YuqueDoc>>(
-        `/repos/${repoId}/docs`,
-        data
-      );
-      return response.data.data;
-    } catch (error) {
-      handleYuqueError(error);
-    }
+  /** Create a new document in a repo. */
+  async createDoc(repoId: string | number, data: CreateDocData): Promise<YuqueDoc> {
+    return withErrorHandling(async () => {
+      const r = await this.client.post<YuqueApiResponse<YuqueDoc>>(`/repos/${repoId}/docs`, data);
+      return r.data.data;
+    });
   }
 
-  async updateDoc(repoId: string | number, docId: string | number, data: {
-    title?: string;
-    slug?: string;
-    body?: string;
-    public?: number;
-  }): Promise<YuqueDoc> {
-    try {
-      const response = await this.client.put<YuqueApiResponse<YuqueDoc>>(
-        `/repos/${repoId}/docs/${docId}`,
-        data
-      );
-      return response.data.data;
-    } catch (error) {
-      handleYuqueError(error);
-    }
+  /** Update an existing document. */
+  async updateDoc(repoId: string | number, docId: string | number, data: UpdateDocData): Promise<YuqueDoc> {
+    return withErrorHandling(async () => {
+      const r = await this.client.put<YuqueApiResponse<YuqueDoc>>(`/repos/${repoId}/docs/${docId}`, data);
+      return r.data.data;
+    });
   }
 
+  /** Delete a document. */
   async deleteDoc(repoId: string | number, docId: string | number): Promise<void> {
-    try {
+    return withErrorHandling(async () => {
       await this.client.delete(`/repos/${repoId}/docs/${docId}`);
-    } catch (error) {
-      handleYuqueError(error);
-    }
+    });
   }
 
-  // TOC APIs
+  // ── TOC APIs ───────────────────────────────────────────────
+
+  /** Get the table of contents for a repo. */
   async getToc(repoId: string | number): Promise<YuqueTocItem[]> {
-    try {
-      const response = await this.client.get<YuqueApiResponse<YuqueTocItem[]>>(
-        `/repos/${repoId}/toc`
-      );
-      return response.data.data;
-    } catch (error) {
-      handleYuqueError(error);
-    }
+    return withErrorHandling(async () => {
+      const r = await this.client.get<YuqueApiResponse<YuqueTocItem[]>>(`/repos/${repoId}/toc`);
+      return r.data.data;
+    });
   }
 
+  /** Update the table of contents for a repo. */
   async updateToc(repoId: string | number, data: string): Promise<YuqueTocItem[]> {
-    try {
-      const response = await this.client.put<YuqueApiResponse<YuqueTocItem[]>>(
-        `/repos/${repoId}/toc`,
-        data
-      );
-      return response.data.data;
-    } catch (error) {
-      handleYuqueError(error);
-    }
+    return withErrorHandling(async () => {
+      const r = await this.client.put<YuqueApiResponse<YuqueTocItem[]>>(`/repos/${repoId}/toc`, data);
+      return r.data.data;
+    });
   }
 
-  // Doc Version APIs
+  // ── Doc Version APIs ───────────────────────────────────────
+
+  /** List all versions of a document. */
   async listDocVersions(docId: number): Promise<YuqueDocVersion[]> {
-    try {
-      const response = await this.client.get<YuqueApiResponse<YuqueDocVersion[]>>(
-        '/doc_versions',
-        { params: { doc_id: docId } }
-      );
-      return response.data.data;
-    } catch (error) {
-      handleYuqueError(error);
-    }
+    return withErrorHandling(async () => {
+      const r = await this.client.get<YuqueApiResponse<YuqueDocVersion[]>>('/doc_versions', {
+        params: { doc_id: docId },
+      });
+      return r.data.data;
+    });
   }
 
+  /** Get a specific version of a document. */
   async getDocVersion(versionId: number): Promise<YuqueDocVersion> {
-    try {
-      const response = await this.client.get<YuqueApiResponse<YuqueDocVersion>>(
-        `/doc_versions/${versionId}`
-      );
-      return response.data.data;
-    } catch (error) {
-      handleYuqueError(error);
-    }
+    return withErrorHandling(async () => {
+      const r = await this.client.get<YuqueApiResponse<YuqueDocVersion>>(`/doc_versions/${versionId}`);
+      return r.data.data;
+    });
   }
 
-  // Group Member APIs
+  // ── Group Member APIs ──────────────────────────────────────
+
+  /** List all members of a group. */
   async listGroupMembers(login: string): Promise<YuqueGroupMember[]> {
-    try {
-      const response = await this.client.get<YuqueApiResponse<YuqueGroupMember[]>>(
-        `/groups/${login}/users`
-      );
-      return response.data.data;
-    } catch (error) {
-      handleYuqueError(error);
-    }
+    return withErrorHandling(async () => {
+      const r = await this.client.get<YuqueApiResponse<YuqueGroupMember[]>>(`/groups/${login}/users`);
+      return r.data.data;
+    });
   }
 
+  /** Update a group member's role. */
   async updateGroupMember(login: string, userId: number, data: { role: number }): Promise<YuqueGroupMember> {
-    try {
-      const response = await this.client.put<YuqueApiResponse<YuqueGroupMember>>(
-        `/groups/${login}/users/${userId}`,
-        data
-      );
-      return response.data.data;
-    } catch (error) {
-      handleYuqueError(error);
-    }
+    return withErrorHandling(async () => {
+      const r = await this.client.put<YuqueApiResponse<YuqueGroupMember>>(`/groups/${login}/users/${userId}`, data);
+      return r.data.data;
+    });
   }
 
+  /** Remove a member from a group. */
   async removeGroupMember(login: string, userId: number): Promise<void> {
-    try {
+    return withErrorHandling(async () => {
       await this.client.delete(`/groups/${login}/users/${userId}`);
-    } catch (error) {
-      handleYuqueError(error);
-    }
+    });
   }
 
-  // Statistics APIs
+  // ── Statistics APIs ────────────────────────────────────────
+
+  /** Get overall statistics for a group. */
   async getGroupStats(login: string): Promise<YuqueStatistics> {
-    try {
-      const response = await this.client.get<YuqueApiResponse<YuqueStatistics>>(
-        `/groups/${login}/statistics`
-      );
-      return response.data.data;
-    } catch (error) {
-      handleYuqueError(error);
-    }
+    return withErrorHandling(async () => {
+      const r = await this.client.get<YuqueApiResponse<YuqueStatistics>>(`/groups/${login}/statistics`);
+      return r.data.data;
+    });
   }
 
+  /** Get member statistics for a group. */
   async getGroupMemberStats(login: string): Promise<unknown> {
-    try {
-      const response = await this.client.get<YuqueApiResponse<unknown>>(
-        `/groups/${login}/statistics/members`
-      );
-      return response.data.data;
-    } catch (error) {
-      handleYuqueError(error);
-    }
+    return withErrorHandling(async () => {
+      const r = await this.client.get<YuqueApiResponse<unknown>>(`/groups/${login}/statistics/members`);
+      return r.data.data;
+    });
   }
 
+  /** Get book/repo statistics for a group. */
   async getGroupBookStats(login: string): Promise<unknown> {
-    try {
-      const response = await this.client.get<YuqueApiResponse<unknown>>(
-        `/groups/${login}/statistics/books`
-      );
-      return response.data.data;
-    } catch (error) {
-      handleYuqueError(error);
-    }
+    return withErrorHandling(async () => {
+      const r = await this.client.get<YuqueApiResponse<unknown>>(`/groups/${login}/statistics/books`);
+      return r.data.data;
+    });
   }
 
+  /** Get document statistics for a group. */
   async getGroupDocStats(login: string): Promise<unknown> {
-    try {
-      const response = await this.client.get<YuqueApiResponse<unknown>>(
-        `/groups/${login}/statistics/docs`
-      );
-      return response.data.data;
-    } catch (error) {
-      handleYuqueError(error);
-    }
+    return withErrorHandling(async () => {
+      const r = await this.client.get<YuqueApiResponse<unknown>>(`/groups/${login}/statistics/docs`);
+      return r.data.data;
+    });
   }
 
-  // Hello API
+  // ── Hello API ──────────────────────────────────────────────
+
+  /** Test API connectivity. */
   async hello(): Promise<{ message: string }> {
-    try {
-      const response = await this.client.get<YuqueApiResponse<{ message: string }>>('/hello');
-      return response.data.data;
-    } catch (error) {
-      handleYuqueError(error);
-    }
+    return withErrorHandling(async () => {
+      const r = await this.client.get<YuqueApiResponse<{ message: string }>>('/hello');
+      return r.data.data;
+    });
   }
 }

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -8,7 +8,7 @@ import type {
   YuqueGroupMember,
 } from '../services/types.js';
 
-// Format user data for AI-friendly output
+/** Format user data — strips fields that are noisy for AI consumption. */
 export function formatUser(user: YuqueUser) {
   return {
     id: user.id,
@@ -21,7 +21,7 @@ export function formatUser(user: YuqueUser) {
   };
 }
 
-// Format group data for AI-friendly output
+/** Format group data for concise AI-friendly output. */
 export function formatGroup(group: YuqueGroup) {
   return {
     id: group.id,
@@ -33,7 +33,7 @@ export function formatGroup(group: YuqueGroup) {
   };
 }
 
-// Format repo data for AI-friendly output
+/** Format repo data — converts numeric `public` field to boolean. */
 export function formatRepo(repo: YuqueRepo) {
   return {
     id: repo.id,
@@ -47,7 +47,7 @@ export function formatRepo(repo: YuqueRepo) {
   };
 }
 
-// Format doc data for AI-friendly output (without body to reduce tokens)
+/** Format doc summary — excludes body to reduce token usage. */
 export function formatDocSummary(doc: YuqueDoc) {
   return {
     id: doc.id,
@@ -60,7 +60,7 @@ export function formatDocSummary(doc: YuqueDoc) {
   };
 }
 
-// Format full doc data including body
+/** Format full doc data including body content. */
 export function formatDoc(doc: YuqueDoc) {
   return {
     ...formatDocSummary(doc),
@@ -70,7 +70,7 @@ export function formatDoc(doc: YuqueDoc) {
   };
 }
 
-// Format TOC data
+/** Format TOC items — flattens to essential navigation fields. */
 export function formatToc(items: YuqueTocItem[]) {
   return items.map((item) => ({
     title: item.title,
@@ -81,7 +81,7 @@ export function formatToc(items: YuqueTocItem[]) {
   }));
 }
 
-// Format doc version
+/** Format doc version — excludes body for list views. */
 export function formatDocVersion(version: YuqueDocVersion) {
   return {
     id: version.id,
@@ -92,7 +92,7 @@ export function formatDocVersion(version: YuqueDocVersion) {
   };
 }
 
-// Format group member
+/** Format group member with optional nested user info. */
 export function formatGroupMember(member: YuqueGroupMember) {
   return {
     id: member.id,


### PR DESCRIPTION
## 代码质量提升

### 改进内容

1. **提取 `withErrorHandling()` 辅助函数** — 消除 YuqueClient 中 27 个重复的 try-catch 块（359→278 行，减少 23%）
2. **提取共享类型定义** — `CreateRepoData`、`UpdateRepoData`、`CreateDocData`、`UpdateDocData` 移入 types.ts，替代重复的内联类型
3. **添加 JSDoc 注释** — 所有 YuqueClient 方法和 format 工具函数
4. **增强错误消息** — 添加 HTTP 状态码提示，方便 AI 诊断（如 401→'YUQUE_TOKEN may be invalid or expired'）
5. **修复版本号** — server.ts 中硬编码的 '0.1.0' 更正为 '0.1.2'

### 验证
- ✅ TypeScript 编译通过（`tsc --noEmit`）
- ✅ 全部 57 个测试通过
- ✅ 无 API 行为变更