### PR TITLE
fix: resolve lint error & bump version to 0.1.3

### DIFF
--- a/tests/tools/repo.test.ts
+++ b/tests/tools/repo.test.ts
@@ -28,7 +28,7 @@ describe('repoTools', () => {
 
     it('should list group repos', async () => {
       (mockClient.listGroupRepos as ReturnType<typeof vi.fn>).mockResolvedValue([mockRepo]);
-      const result = await repoTools.yuque_list_repos.handler(mockClient, { login: 'grp', type: 'group' } as never);
+      await repoTools.yuque_list_repos.handler(mockClient, { login: 'grp', type: 'group' } as never);
       expect(mockClient.listGroupRepos).toHaveBeenCalledWith('grp');
     });
   });


### PR DESCRIPTION
## Changes

- **Fix lint error**: Remove unused `result` variable assignment in `tests/tools/repo.test.ts:31` (was causing CI failure)
- **Bump version**: `0.1.1` → `0.1.3` in `package.json`

## Verification

- ✅ `eslint` passes with 0 errors
- ✅ All 57 tests pass (8 test files)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated test code structure for repository operations without affecting test coverage or assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->