### PR TITLE
chore: update org links from chen201724 to yuque

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,5 +23,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Docker support
 - Documentation in English and Chinese
 
-[Unreleased]: https://github.com/chen201724/yuque-mcp-server/compare/v0.1.0...HEAD
-[0.1.0]: https://github.com/chen201724/yuque-mcp-server/releases/tag/v0.1.0
+[Unreleased]: https://github.com/yuque/yuque-mcp-server/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/yuque/yuque-mcp-server/releases/tag/v0.1.0

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -18,7 +18,7 @@ Unacceptable behavior:
 
 ## Enforcement
 
-Report issues via [GitHub Issues](https://github.com/chen201724/yuque-mcp-server/issues). All complaints will be reviewed promptly.
+Report issues via [GitHub Issues](https://github.com/yuque/yuque-mcp-server/issues). All complaints will be reviewed promptly.
 
 ## Attribution
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Thank you for your interest in contributing! 🎉
 
 ```bash
 # Clone and install
-git clone https://github.com/chen201724/yuque-mcp-server.git
+git clone https://github.com/yuque/yuque-mcp-server.git
 cd yuque-mcp-server
 npm install
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Yuque MCP Server
 
-[![CI](https://github.com/chen201724/yuque-mcp-server/actions/workflows/ci.yml/badge.svg)](https://github.com/chen201724/yuque-mcp-server/actions/workflows/ci.yml)
+[![CI](https://github.com/yuque/yuque-mcp-server/actions/workflows/ci.yml/badge.svg)](https://github.com/yuque/yuque-mcp-server/actions/workflows/ci.yml)
 [![npm version](https://img.shields.io/npm/v/yuque-mcp)](https://www.npmjs.com/package/yuque-mcp)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 MCP server for [Yuque (语雀)](https://www.yuque.com/) — expose your knowledge base to AI assistants through the [Model Context Protocol](https://modelcontextprotocol.io/).
 
-🌐 **[Website](https://chen201724.github.io/yuque-ecosystem/)** · [中文文档](./README.zh-CN.md)
+🌐 **[Website](https://yuque.github.io/yuque-ecosystem/)** · [中文文档](./README.zh-CN.md)
 
 ## Quick Start
 
@@ -52,7 +52,7 @@ Ask your AI assistant to search your Yuque docs, create documents, or manage rep
 ## Development
 
 ```bash
-git clone https://github.com/chen201724/yuque-mcp-server.git
+git clone https://github.com/yuque/yuque-mcp-server.git
 cd yuque-mcp-server
 npm install
 npm test              # run tests (57 tests)
@@ -66,4 +66,4 @@ npm run dev           # dev mode with hot reload
 
 ## Links
 
-- [Website](https://chen201724.github.io/yuque-ecosystem/) · [Yuque API Docs](https://www.yuque.com/yuque/developer/api) · [MCP Protocol](https://modelcontextprotocol.io/) · [Contributing](./CONTRIBUTING.md)
+- [Website](https://yuque.github.io/yuque-ecosystem/) · [Yuque API Docs](https://www.yuque.com/yuque/developer/api) · [MCP Protocol](https://modelcontextprotocol.io/) · [Contributing](./CONTRIBUTING.md)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,12 +1,12 @@
 # Yuque MCP Server
 
-[![CI](https://github.com/chen201724/yuque-mcp-server/actions/workflows/ci.yml/badge.svg)](https://github.com/chen201724/yuque-mcp-server/actions/workflows/ci.yml)
+[![CI](https://github.com/yuque/yuque-mcp-server/actions/workflows/ci.yml/badge.svg)](https://github.com/yuque/yuque-mcp-server/actions/workflows/ci.yml)
 [![npm version](https://img.shields.io/npm/v/yuque-mcp)](https://www.npmjs.com/package/yuque-mcp)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 [语雀](https://www.yuque.com/) MCP Server — 通过 [Model Context Protocol](https://modelcontextprotocol.io/) 让 AI 助手访问你的语雀知识库。
 
-🌐 **[官网](https://chen201724.github.io/yuque-ecosystem/)** · [English](./README.md)
+🌐 **[官网](https://yuque.github.io/yuque-ecosystem/)** · [English](./README.md)
 
 ## 快速开始
 
@@ -51,7 +51,7 @@ claude mcp add yuque-mcp -- npx -y yuque-mcp --token=YOUR_TOKEN
 ## 开发
 
 ```bash
-git clone https://github.com/chen201724/yuque-mcp-server.git
+git clone https://github.com/yuque/yuque-mcp-server.git
 cd yuque-mcp-server
 npm install
 npm test              # 运行测试（57 个测试用例）
@@ -65,4 +65,4 @@ npm run dev           # 开发模式
 
 ## 链接
 
-- [官网](https://chen201724.github.io/yuque-ecosystem/) · [语雀 API 文档](https://www.yuque.com/yuque/developer/api) · [MCP 协议](https://modelcontextprotocol.io/) · [贡献指南](./CONTRIBUTING.md)
+- [官网](https://yuque.github.io/yuque-ecosystem/) · [语雀 API 文档](https://www.yuque.com/yuque/developer/api) · [MCP 协议](https://modelcontextprotocol.io/) · [贡献指南](./CONTRIBUTING.md)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Reporting a Vulnerability
 
-Please open a [security advisory](https://github.com/chen201724/yuque-mcp-server/security/advisories/new) on GitHub. Do not open public issues for security vulnerabilities.
+Please open a [security advisory](https://github.com/yuque/yuque-mcp-server/security/advisories/new) on GitHub. Do not open public issues for security vulnerabilities.
 
 ## Security Best Practices
 

--- a/package.json
+++ b/package.json
@@ -36,16 +36,16 @@
     "claude",
     "cursor"
   ],
-  "author": "chen201724",
+  "author": "yuque",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/chen201724/yuque-mcp-server.git"
+    "url": "https://github.com/yuque/yuque-mcp-server.git"
   },
   "bugs": {
-    "url": "https://github.com/chen201724/yuque-mcp-server/issues"
+    "url": "https://github.com/yuque/yuque-mcp-server/issues"
   },
-  "homepage": "https://github.com/chen201724/yuque-mcp-server#readme",
+  "homepage": "https://github.com/yuque/yuque-mcp-server#readme",
   "engines": {
     "node": ">=18.0.0"
   },


### PR DESCRIPTION
## Summary

Migrate all references after repo transfer from `chen201724/yuque-mcp-server` to `yuque/yuque-mcp-server`.

### Changes
- **package.json**: updated `repository`, `homepage`, `bugs`, `author` fields
- **README.md & README.zh-CN.md**: updated CI badges, clone URLs, website links
- **CHANGELOG.md**: updated compare/release links
- **CONTRIBUTING.md**: updated clone URL
- **CODE_OF_CONDUCT.md**: updated issues link
- **SECURITY.md**: updated security advisory link
- **Website links**: `chen201724.github.io/yuque-ecosystem` → `yuque.github.io/yuque-ecosystem`

### Verification
```bash
grep -rn chen201724 . --include='*' # returns nothing
```

No remaining references to the old org.