### PR TITLE
feat: add server.json and mcpName for MCP Registry

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "yuque-mcp",
   "version": "0.1.4",
   "description": "MCP server for Yuque (语雀) — expose Yuque knowledge base to AI assistants via Model Context Protocol",
+  "mcpName": "io.github.yuque/yuque-mcp",
   "type": "module",
   "main": "dist/cli.js",
   "bin": {

--- a/server.json
+++ b/server.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.yuque/yuque-mcp",
+  "description": "MCP server for Yuque (语雀) — expose your knowledge base to AI assistants. Supports document CRUD, search, repo management, team collaboration, and statistics.",
+  "repository": {
+    "url": "https://github.com/yuque/yuque-mcp-server",
+    "source": "github"
+  },
+  "version": "0.1.4",
+  "packages": [
+    {
+      "registryType": "npm",
+      "identifier": "yuque-mcp",
+      "version": "0.1.4",
+      "transport": {
+        "type": "stdio"
+      },
+      "environmentVariables": [
+        {
+          "name": "YUQUE_PERSONAL_TOKEN",
+          "description": "Yuque personal API token (get from https://www.yuque.com/settings/tokens). Use one of: YUQUE_PERSONAL_TOKEN, YUQUE_GROUP_TOKEN, or YUQUE_TOKEN.",
+          "isRequired": false,
+          "isSecret": true,
+          "format": "string"
+        },
+        {
+          "name": "YUQUE_GROUP_TOKEN",
+          "description": "Yuque group/team API token (alternative to YUQUE_PERSONAL_TOKEN for team workspaces).",
+          "isRequired": false,
+          "isSecret": true,
+          "format": "string"
+        },
+        {
+          "name": "YUQUE_TOKEN",
+          "description": "Yuque API token (legacy, use YUQUE_PERSONAL_TOKEN or YUQUE_GROUP_TOKEN instead).",
+          "isRequired": false,
+          "isSecret": true,
+          "format": "string"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## 🎯 Purpose

Prepare yuque-mcp for publishing to the [official MCP Registry](https://registry.modelcontextprotocol.io/).

## 📝 Changes

### 1. `server.json` (new file)
MCP Registry metadata describing yuque-mcp:
- Name: `io.github.yuque/yuque-mcp`
- Package: `yuque-mcp` on npm
- Transport: stdio
- Environment variables: `YUQUE_PERSONAL_TOKEN`, `YUQUE_GROUP_TOKEN`, `YUQUE_TOKEN` (all optional, use one)

### 2. `package.json`
- Added `mcpName` field (`io.github.yuque/yuque-mcp`) for registry verification

## 🔗 Next Steps

After merge:
1. Publish 0.1.4 to npm
2. Install `mcp-publisher` CLI
3. Authenticate with GitHub (`mcp-publisher login github`)
4. Publish to registry (`mcp-publisher publish`)

## 📚 Reference

- [MCP Registry Quickstart](https://github.com/modelcontextprotocol/registry/blob/main/docs/modelcontextprotocol-io/quickstart.mdx)
- [MCP Registry](https://registry.modelcontextprotocol.io/)