### PR TITLE
docs: rewrite README with multi-client installation guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,21 @@ Add to your Cline MCP settings (`~/Library/Application Support/Code/User/globalS
 
 </details>
 
+<details>
+<summary><b>Trae</b></summary>
+
+In Trae, open **Settings** and navigate to the **MCP** section, then add a new stdio-type MCP Server with the following configuration:
+
+- **Command:** `npx`
+- **Args:** `-y yuque-mcp`
+- **Env:** `YUQUE_PERSONAL_TOKEN=YOUR_TOKEN`
+
+See [Trae MCP documentation](https://docs.trae.ai/ide/model-context-protocol) for detailed instructions.
+
+</details>
+
+> **More clients:** Any MCP-compatible client that supports stdio transport can use yuque-mcp. The general pattern is: command = `npx`, args = `["-y", "yuque-mcp"]`, env = `YUQUE_PERSONAL_TOKEN`.
+
 ### 3. Done!
 
 Ask your AI assistant to search your Yuque docs, create documents, or manage books.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -146,6 +146,21 @@ claude mcp add yuque-mcp -- npx -y yuque-mcp
 
 </details>
 
+<details>
+<summary><b>Trae</b></summary>
+
+在 Trae 中，打开 **设置**，进入 **MCP** 部分，添加一个 stdio 类型的 MCP Server，配置如下：
+
+- **Command:** `npx`
+- **Args:** `-y yuque-mcp`
+- **Env:** `YUQUE_PERSONAL_TOKEN=YOUR_TOKEN`
+
+详见 [Trae MCP 文档](https://docs.trae.ai/ide/model-context-protocol)。
+
+</details>
+
+> **更多客户端：** 任何支持 stdio 传输的 MCP 客户端均可使用 yuque-mcp。通用配置：command = `npx`，args = `["-y", "yuque-mcp"]`，env = `YUQUE_PERSONAL_TOKEN`。
+
 ### 3. 开始使用！
 
 让 AI 助手搜索语雀文档、创建文档、管理知识库。


### PR DESCRIPTION
## Summary

Rewrites both `README.md` (English) and `README.zh-CN.md` (Chinese) with comprehensive installation guides for all major MCP clients.

## Changes

### Multi-client Installation Guides
Added step-by-step setup instructions with JSON/CLI configurations for:
- **Claude Code** — CLI command
- **Claude Desktop** — `claude_desktop_config.json`
- **VS Code (GitHub Copilot)** — `.vscode/mcp.json` (uses `servers` key)
- **Cursor** — `~/.cursor/mcp.json`
- **Windsurf** — `~/.windsurf/mcp.json`
- **Cline (VS Code)** — Cline MCP settings
- **Trae** — Settings > MCP UI-based setup (with link to Trae MCP docs)

### Authentication Section
- Dedicated section documenting all supported token methods
- Clear priority order: `YUQUE_PERSONAL_TOKEN` > `YUQUE_GROUP_TOKEN` > `YUQUE_TOKEN` > `--token`

### Other Improvements
- Collapsible `<details>` sections for cleaner navigation
- Config file paths for each platform (macOS/Windows)
- Generic note for any stdio-compatible MCP client
- Added `npx` not found troubleshooting entry
- Added MCP Registry and API Docs to Links section
- Consistent structure between EN and CN versions

### Research Notes on Chinese AI IDEs
- **Trae**: ✅ Confirmed MCP support ([docs](https://docs.trae.ai/ide/model-context-protocol)). Uses UI-based MCP Server management.
- **通义灵码 (Tongyi Lingma)**: No MCP support found as of this writing.
- **MarsCode (豆包 IDE)**: Merged into Trae (docs.marscode.com redirects to docs.trae.ai).

## No Code Changes
Documentation only — no changes to `package.json`, source code, or tests.