### PR TITLE
feat: add install and setup CLI commands for quick MCP client configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,28 @@ MCP server for [Yuque (语雀)](https://www.yuque.com/) — expose your knowledg
 
 Visit [Yuque Developer Settings](https://www.yuque.com/settings/tokens) to create a personal access token.
 
-### 2. Add to Your MCP Client
+### 2. Quick Install (Recommended)
+
+Use the built-in CLI to auto-configure your MCP client in one command:
+
+```bash
+npx yuque-mcp install --token=YOUR_TOKEN --client=cursor
+```
+
+Supported clients: `claude-desktop`, `vscode`, `cursor`, `windsurf`, `cline`, `trae`
+
+Or use the interactive setup wizard:
+
+```bash
+npx yuque-mcp setup
+```
+
+The CLI will automatically find the correct config file for your OS, merge with any existing configuration (without overwriting other servers), and print a success message.
+
+### 3. Manual Configuration
+
+<details>
+<summary>Prefer to configure manually? Click to expand all client configs.</summary>
 
 Choose your preferred client below:
 
@@ -161,7 +182,9 @@ See [Trae MCP documentation](https://docs.trae.ai/ide/model-context-protocol) fo
 
 > **More clients:** Any MCP-compatible client that supports stdio transport can use yuque-mcp. The general pattern is: command = `npx`, args = `["-y", "yuque-mcp"]`, env = `YUQUE_PERSONAL_TOKEN`.
 
-### 3. Done!
+</details>
+
+### 4. Done!
 
 Ask your AI assistant to search your Yuque docs, create documents, or manage books.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -16,7 +16,28 @@
 
 前往 [语雀开发者设置](https://www.yuque.com/settings/tokens) 创建个人访问令牌。
 
-### 2. 添加到 MCP 客户端
+### 2. 快速安装（推荐）
+
+使用内置 CLI 命令一键配置 MCP 客户端：
+
+```bash
+npx yuque-mcp install --token=YOUR_TOKEN --client=cursor
+```
+
+支持的客户端：`claude-desktop`、`vscode`、`cursor`、`windsurf`、`cline`、`trae`
+
+或使用交互式安装向导：
+
+```bash
+npx yuque-mcp setup
+```
+
+CLI 会自动找到对应操作系统的配置文件路径，与已有配置合并（不会覆盖其他服务器），并打印成功信息。
+
+### 3. 手动配置
+
+<details>
+<summary>偏好手动配置？点击展开所有客户端配置。</summary>
 
 选择你使用的客户端：
 
@@ -161,7 +182,9 @@ claude mcp add yuque-mcp -- npx -y yuque-mcp
 
 > **更多客户端：** 任何支持 stdio 传输的 MCP 客户端均可使用 yuque-mcp。通用配置：command = `npx`，args = `["-y", "yuque-mcp"]`，env = `YUQUE_PERSONAL_TOKEN`。
 
-### 3. 开始使用！
+</details>
+
+### 4. 开始使用！
 
 让 AI 助手搜索语雀文档、创建文档、管理知识库。
 

--- a/src/cli-install.ts
+++ b/src/cli-install.ts
@@ -1,0 +1,331 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import * as readline from 'node:readline';
+
+// ─── Client Definitions ───────────────────────────────────────────────
+
+type ClientId = 'claude-desktop' | 'vscode' | 'cursor' | 'windsurf' | 'cline' | 'trae';
+
+interface ClientConfig {
+  name: string;
+  configKey: 'mcpServers' | 'servers';
+  getConfigPath: () => string;
+}
+
+function getAppDataPath(): string {
+  if (process.platform === 'win32') {
+    return process.env.APPDATA || path.join(os.homedir(), 'AppData', 'Roaming');
+  }
+  return '';
+}
+
+function getConfigHome(): string {
+  if (process.platform === 'linux') {
+    return process.env.XDG_CONFIG_HOME || path.join(os.homedir(), '.config');
+  }
+  return '';
+}
+
+const CLIENT_CONFIGS: Record<ClientId, ClientConfig> = {
+  'claude-desktop': {
+    name: 'Claude Desktop',
+    configKey: 'mcpServers',
+    getConfigPath() {
+      switch (process.platform) {
+        case 'darwin':
+          return path.join(os.homedir(), 'Library', 'Application Support', 'Claude', 'claude_desktop_config.json');
+        case 'win32':
+          return path.join(getAppDataPath(), 'Claude', 'claude_desktop_config.json');
+        default:
+          return path.join(getConfigHome() || path.join(os.homedir(), '.config'), 'Claude', 'claude_desktop_config.json');
+      }
+    },
+  },
+  vscode: {
+    name: 'VS Code',
+    configKey: 'servers',
+    getConfigPath() {
+      return path.join(process.cwd(), '.vscode', 'mcp.json');
+    },
+  },
+  cursor: {
+    name: 'Cursor',
+    configKey: 'mcpServers',
+    getConfigPath() {
+      return path.join(os.homedir(), '.cursor', 'mcp.json');
+    },
+  },
+  windsurf: {
+    name: 'Windsurf',
+    configKey: 'mcpServers',
+    getConfigPath() {
+      return path.join(os.homedir(), '.windsurf', 'mcp.json');
+    },
+  },
+  cline: {
+    name: 'Cline',
+    configKey: 'mcpServers',
+    getConfigPath() {
+      switch (process.platform) {
+        case 'darwin':
+          return path.join(
+            os.homedir(),
+            'Library',
+            'Application Support',
+            'Code',
+            'User',
+            'globalStorage',
+            'saoudrizwan.claude-dev',
+            'settings',
+            'cline_mcp_settings.json'
+          );
+        case 'win32':
+          return path.join(
+            getAppDataPath(),
+            'Code',
+            'User',
+            'globalStorage',
+            'saoudrizwan.claude-dev',
+            'settings',
+            'cline_mcp_settings.json'
+          );
+        default:
+          return path.join(
+            getConfigHome() || path.join(os.homedir(), '.config'),
+            'Code',
+            'User',
+            'globalStorage',
+            'saoudrizwan.claude-dev',
+            'settings',
+            'cline_mcp_settings.json'
+          );
+      }
+    },
+  },
+  trae: {
+    name: 'Trae',
+    configKey: 'mcpServers',
+    getConfigPath() {
+      switch (process.platform) {
+        case 'darwin':
+          return path.join(os.homedir(), 'Library', 'Application Support', 'Trae', 'User', 'globalStorage', 'trae-ai.trae-core', 'settings', 'cline_mcp_settings.json');
+        case 'win32':
+          return path.join(getAppDataPath(), 'Trae', 'User', 'globalStorage', 'trae-ai.trae-core', 'settings', 'cline_mcp_settings.json');
+        default:
+          return path.join(
+            getConfigHome() || path.join(os.homedir(), '.config'),
+            'Trae',
+            'User',
+            'globalStorage',
+            'trae-ai.trae-core',
+            'settings',
+            'cline_mcp_settings.json'
+          );
+      }
+    },
+  },
+};
+
+// ─── Config Generation ────────────────────────────────────────────────
+
+function buildServerEntry(token: string) {
+  return {
+    command: 'npx',
+    args: ['-y', 'yuque-mcp'],
+    env: {
+      YUQUE_PERSONAL_TOKEN: token,
+    },
+  };
+}
+
+// ─── Install Logic ────────────────────────────────────────────────────
+
+export interface InstallOptions {
+  token: string;
+  client: ClientId;
+}
+
+export function getSupportedClients(): ClientId[] {
+  return Object.keys(CLIENT_CONFIGS) as ClientId[];
+}
+
+export function getClientConfig(client: ClientId): ClientConfig | undefined {
+  return CLIENT_CONFIGS[client];
+}
+
+/**
+ * Install yuque-mcp config into the specified client's config file.
+ * Returns the path that was written to.
+ */
+export function installToClient(options: InstallOptions): string {
+  const clientConfig = CLIENT_CONFIGS[options.client];
+  if (!clientConfig) {
+    throw new Error(
+      `Unknown client: "${options.client}". Supported clients: ${getSupportedClients().join(', ')}`
+    );
+  }
+
+  const configPath = clientConfig.getConfigPath();
+  const configKey = clientConfig.configKey;
+
+  // Read existing config or start fresh
+  let config: Record<string, unknown> = {};
+  if (fs.existsSync(configPath)) {
+    try {
+      const raw = fs.readFileSync(configPath, 'utf-8');
+      config = JSON.parse(raw) as Record<string, unknown>;
+    } catch {
+      // If the file exists but is invalid JSON, back it up and start fresh
+      const backupPath = configPath + '.backup';
+      fs.copyFileSync(configPath, backupPath);
+      console.log(`⚠️  Existing config was invalid JSON. Backed up to: ${backupPath}`);
+      config = {};
+    }
+  }
+
+  // Ensure the servers/mcpServers key exists
+  if (!config[configKey] || typeof config[configKey] !== 'object') {
+    config[configKey] = {};
+  }
+
+  // Inject/update the yuque entry
+  const serversObj = config[configKey] as Record<string, unknown>;
+  serversObj['yuque'] = buildServerEntry(options.token);
+
+  // Create parent directories if needed
+  const dir = path.dirname(configPath);
+  fs.mkdirSync(dir, { recursive: true });
+
+  // Write the config file
+  fs.writeFileSync(configPath, JSON.stringify(config, null, 2) + '\n', 'utf-8');
+
+  return configPath;
+}
+
+// ─── CLI: install subcommand ──────────────────────────────────────────
+
+export function runInstall(args: string[]): void {
+  const tokenArg = args.find((a) => a.startsWith('--token='));
+  const clientArg = args.find((a) => a.startsWith('--client='));
+
+  if (!tokenArg) {
+    console.error('Error: --token=YOUR_TOKEN is required.');
+    console.error('Usage: npx yuque-mcp install --token=YOUR_TOKEN --client=CLIENT');
+    console.error(`Supported clients: ${getSupportedClients().join(', ')}`);
+    process.exit(1);
+  }
+
+  if (!clientArg) {
+    console.error('Error: --client=CLIENT is required.');
+    console.error('Usage: npx yuque-mcp install --token=YOUR_TOKEN --client=CLIENT');
+    console.error(`Supported clients: ${getSupportedClients().join(', ')}`);
+    process.exit(1);
+  }
+
+  const token = tokenArg.split('=').slice(1).join('=');
+  const client = clientArg.split('=').slice(1).join('=') as ClientId;
+
+  if (!token) {
+    console.error('Error: Token value cannot be empty.');
+    process.exit(1);
+  }
+
+  try {
+    const configPath = installToClient({ token, client });
+    const clientName = CLIENT_CONFIGS[client]?.name ?? client;
+    console.log(`\n✅ Successfully configured yuque-mcp for ${clientName}!`);
+    console.log(`   Config file: ${configPath}`);
+    console.log(`\n   Restart ${clientName} to activate the MCP server.\n`);
+  } catch (error) {
+    if (error instanceof Error) {
+      console.error(`\n❌ ${error.message}\n`);
+    } else {
+      console.error('\n❌ An unexpected error occurred.\n');
+    }
+    process.exit(1);
+  }
+}
+
+// ─── CLI: setup subcommand (interactive) ──────────────────────────────
+
+function askQuestion(rl: readline.Interface, question: string): Promise<string> {
+  return new Promise((resolve) => {
+    rl.question(question, (answer: string) => {
+      resolve(answer.trim());
+    });
+  });
+}
+
+export async function runSetup(): Promise<void> {
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+
+  try {
+    console.log('\n🚀 Yuque MCP Server — Quick Setup\n');
+
+    // Step 1: Ask for token
+    console.log('Step 1: Enter your Yuque API token');
+    console.log('   (Get one at https://www.yuque.com/settings/tokens)\n');
+    const token = await askQuestion(rl, '   Token: ');
+    if (!token) {
+      console.error('\n❌ Token cannot be empty.\n');
+      process.exit(1);
+    }
+
+    // Step 2: Select client
+    const clients = getSupportedClients();
+    console.log('\nStep 2: Select your MCP client\n');
+    clients.forEach((id, i) => {
+      const config = CLIENT_CONFIGS[id];
+      console.log(`   ${i + 1}) ${config.name} (${id})`);
+    });
+    console.log('');
+
+    const choice = await askQuestion(rl, '   Enter number (1-' + clients.length + '): ');
+    const idx = parseInt(choice, 10) - 1;
+    if (isNaN(idx) || idx < 0 || idx >= clients.length) {
+      console.error('\n❌ Invalid selection.\n');
+      process.exit(1);
+    }
+
+    const client = clients[idx];
+
+    // Step 3: Install
+    console.log('');
+    const configPath = installToClient({ token, client });
+    const clientName = CLIENT_CONFIGS[client].name;
+    console.log(`✅ Successfully configured yuque-mcp for ${clientName}!`);
+    console.log(`   Config file: ${configPath}`);
+    console.log(`\n   Restart ${clientName} to activate the MCP server.\n`);
+  } finally {
+    rl.close();
+  }
+}
+
+// ─── Entry: detect subcommands ────────────────────────────────────────
+
+/**
+ * Check if the CLI was invoked with install or setup subcommand.
+ * Returns true if handled (caller should exit), false otherwise.
+ */
+export function handleCliSubcommands(argv: string[]): boolean {
+  const subcommand = argv[2]; // argv[0] = node, argv[1] = script
+
+  if (subcommand === 'install') {
+    runInstall(argv.slice(3));
+    return true;
+  }
+
+  if (subcommand === 'setup') {
+    runSetup().catch((error) => {
+      console.error('Setup failed:', error);
+      process.exit(1);
+    });
+    return true;
+  }
+
+  return false;
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,18 +1,26 @@
 #!/usr/bin/env node
+import { handleCliSubcommands } from './cli-install.js';
 import { runStdioServer } from './server.js';
 
-const token =
-  process.env.YUQUE_PERSONAL_TOKEN ||
-  process.env.YUQUE_GROUP_TOKEN ||
-  process.env.YUQUE_TOKEN ||
-  process.argv.find((arg) => arg.startsWith('--token='))?.split('=')[1];
+// Handle install/setup subcommands before starting the MCP server
+if (handleCliSubcommands(process.argv)) {
+  // Subcommand was handled — do not start the server.
+  // For async subcommands (setup), the process will exit when done.
+} else {
+  // Normal MCP server startup
+  const token =
+    process.env.YUQUE_PERSONAL_TOKEN ||
+    process.env.YUQUE_GROUP_TOKEN ||
+    process.env.YUQUE_TOKEN ||
+    process.argv.find((arg) => arg.startsWith('--token='))?.split('=')[1];
 
-if (!token) {
-  console.error('Error: YUQUE_PERSONAL_TOKEN, YUQUE_GROUP_TOKEN, or YUQUE_TOKEN environment variable (or --token argument) is required');
-  process.exit(1);
+  if (!token) {
+    console.error('Error: YUQUE_PERSONAL_TOKEN, YUQUE_GROUP_TOKEN, or YUQUE_TOKEN environment variable (or --token argument) is required');
+    process.exit(1);
+  }
+
+  runStdioServer(token).catch((error) => {
+    console.error('Fatal error:', error);
+    process.exit(1);
+  });
 }
-
-runStdioServer(token).catch((error) => {
-  console.error('Fatal error:', error);
-  process.exit(1);
-});

--- a/tests/cli-install.test.ts
+++ b/tests/cli-install.test.ts
@@ -1,0 +1,306 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { installToClient, getSupportedClients, getClientConfig } from '../src/cli-install.js';
+
+// Use a temp directory for all file operations
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'yuque-mcp-test-'));
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+/**
+ * Helper: override the config path for a client by monkey-patching getConfigPath
+ */
+function mockConfigPath(client: string, configPath: string) {
+  const clientConfig = getClientConfig(client as never);
+  if (!clientConfig) throw new Error(`Unknown client: ${client}`);
+  clientConfig.getConfigPath = () => configPath;
+}
+
+describe('getSupportedClients', () => {
+  it('should return all 6 supported clients', () => {
+    const clients = getSupportedClients();
+    expect(clients).toContain('claude-desktop');
+    expect(clients).toContain('vscode');
+    expect(clients).toContain('cursor');
+    expect(clients).toContain('windsurf');
+    expect(clients).toContain('cline');
+    expect(clients).toContain('trae');
+    expect(clients.length).toBe(6);
+  });
+});
+
+describe('getClientConfig', () => {
+  it('should return config for valid client', () => {
+    const config = getClientConfig('cursor');
+    expect(config).toBeDefined();
+    expect(config?.name).toBe('Cursor');
+    expect(config?.configKey).toBe('mcpServers');
+  });
+
+  it('should return config with servers key for vscode', () => {
+    const config = getClientConfig('vscode');
+    expect(config).toBeDefined();
+    expect(config?.name).toBe('VS Code');
+    expect(config?.configKey).toBe('servers');
+  });
+
+  it('should return undefined for unknown client', () => {
+    const config = getClientConfig('nonexistent' as never);
+    expect(config).toBeUndefined();
+  });
+});
+
+describe('installToClient', () => {
+  it('should create a new config file for cursor (mcpServers format)', () => {
+    const configPath = path.join(tmpDir, 'cursor', 'mcp.json');
+    mockConfigPath('cursor', configPath);
+
+    const result = installToClient({ token: 'test-token-123', client: 'cursor' });
+
+    expect(result).toBe(configPath);
+    expect(fs.existsSync(configPath)).toBe(true);
+
+    const content = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+    expect(content).toEqual({
+      mcpServers: {
+        yuque: {
+          command: 'npx',
+          args: ['-y', 'yuque-mcp'],
+          env: {
+            YUQUE_PERSONAL_TOKEN: 'test-token-123',
+          },
+        },
+      },
+    });
+  });
+
+  it('should create a new config file for vscode (servers format)', () => {
+    const configPath = path.join(tmpDir, '.vscode', 'mcp.json');
+    mockConfigPath('vscode', configPath);
+
+    const result = installToClient({ token: 'vsc-token', client: 'vscode' });
+
+    expect(result).toBe(configPath);
+    const content = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+    expect(content).toEqual({
+      servers: {
+        yuque: {
+          command: 'npx',
+          args: ['-y', 'yuque-mcp'],
+          env: {
+            YUQUE_PERSONAL_TOKEN: 'vsc-token',
+          },
+        },
+      },
+    });
+  });
+
+  it('should merge with existing config (preserve other servers)', () => {
+    const configPath = path.join(tmpDir, 'existing', 'mcp.json');
+    fs.mkdirSync(path.dirname(configPath), { recursive: true });
+    fs.writeFileSync(
+      configPath,
+      JSON.stringify(
+        {
+          mcpServers: {
+            'other-server': {
+              command: 'other',
+              args: ['--flag'],
+            },
+          },
+        },
+        null,
+        2
+      ),
+      'utf-8'
+    );
+
+    mockConfigPath('cursor', configPath);
+    installToClient({ token: 'merge-token', client: 'cursor' });
+
+    const content = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+    // Original server should still be there
+    expect(content.mcpServers['other-server']).toEqual({
+      command: 'other',
+      args: ['--flag'],
+    });
+    // New server should be added
+    expect(content.mcpServers['yuque']).toEqual({
+      command: 'npx',
+      args: ['-y', 'yuque-mcp'],
+      env: {
+        YUQUE_PERSONAL_TOKEN: 'merge-token',
+      },
+    });
+  });
+
+  it('should update existing yuque entry without duplicating', () => {
+    const configPath = path.join(tmpDir, 'update', 'mcp.json');
+    fs.mkdirSync(path.dirname(configPath), { recursive: true });
+    fs.writeFileSync(
+      configPath,
+      JSON.stringify(
+        {
+          mcpServers: {
+            yuque: {
+              command: 'npx',
+              args: ['-y', 'yuque-mcp'],
+              env: {
+                YUQUE_PERSONAL_TOKEN: 'old-token',
+              },
+            },
+          },
+        },
+        null,
+        2
+      ),
+      'utf-8'
+    );
+
+    mockConfigPath('cursor', configPath);
+    installToClient({ token: 'new-token', client: 'cursor' });
+
+    const content = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+    expect(content.mcpServers['yuque'].env.YUQUE_PERSONAL_TOKEN).toBe('new-token');
+    // Should only have one entry
+    expect(Object.keys(content.mcpServers)).toEqual(['yuque']);
+  });
+
+  it('should preserve other top-level keys in the config', () => {
+    const configPath = path.join(tmpDir, 'preserve', 'mcp.json');
+    fs.mkdirSync(path.dirname(configPath), { recursive: true });
+    fs.writeFileSync(
+      configPath,
+      JSON.stringify(
+        {
+          someOtherSetting: true,
+          mcpServers: {},
+        },
+        null,
+        2
+      ),
+      'utf-8'
+    );
+
+    mockConfigPath('cursor', configPath);
+    installToClient({ token: 'tok', client: 'cursor' });
+
+    const content = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+    expect(content.someOtherSetting).toBe(true);
+    expect(content.mcpServers.yuque).toBeDefined();
+  });
+
+  it('should create parent directories recursively', () => {
+    const configPath = path.join(tmpDir, 'deep', 'nested', 'dir', 'mcp.json');
+    mockConfigPath('cursor', configPath);
+
+    installToClient({ token: 'deep-token', client: 'cursor' });
+
+    expect(fs.existsSync(configPath)).toBe(true);
+    const content = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+    expect(content.mcpServers.yuque.env.YUQUE_PERSONAL_TOKEN).toBe('deep-token');
+  });
+
+  it('should throw for unknown client', () => {
+    expect(() => {
+      installToClient({ token: 'tok', client: 'unknown-client' as never });
+    }).toThrow('Unknown client');
+  });
+
+  it('should handle invalid JSON in existing file (backup and recreate)', () => {
+    const configPath = path.join(tmpDir, 'invalid', 'mcp.json');
+    fs.mkdirSync(path.dirname(configPath), { recursive: true });
+    fs.writeFileSync(configPath, '{ invalid json !!!', 'utf-8');
+
+    mockConfigPath('cursor', configPath);
+    installToClient({ token: 'fix-token', client: 'cursor' });
+
+    // Backup should exist
+    expect(fs.existsSync(configPath + '.backup')).toBe(true);
+    // New valid config should exist
+    const content = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+    expect(content.mcpServers.yuque.env.YUQUE_PERSONAL_TOKEN).toBe('fix-token');
+  });
+
+  it('should work for claude-desktop client', () => {
+    const configPath = path.join(tmpDir, 'claude', 'claude_desktop_config.json');
+    mockConfigPath('claude-desktop', configPath);
+
+    installToClient({ token: 'claude-tok', client: 'claude-desktop' });
+
+    const content = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+    expect(content.mcpServers.yuque).toBeDefined();
+    expect(content.mcpServers.yuque.command).toBe('npx');
+  });
+
+  it('should work for windsurf client', () => {
+    const configPath = path.join(tmpDir, 'windsurf', 'mcp.json');
+    mockConfigPath('windsurf', configPath);
+
+    installToClient({ token: 'wind-tok', client: 'windsurf' });
+
+    const content = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+    expect(content.mcpServers.yuque).toBeDefined();
+  });
+
+  it('should work for cline client', () => {
+    const configPath = path.join(tmpDir, 'cline', 'settings.json');
+    mockConfigPath('cline', configPath);
+
+    installToClient({ token: 'cline-tok', client: 'cline' });
+
+    const content = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+    expect(content.mcpServers.yuque).toBeDefined();
+  });
+
+  it('should work for trae client', () => {
+    const configPath = path.join(tmpDir, 'trae', 'settings.json');
+    mockConfigPath('trae', configPath);
+
+    installToClient({ token: 'trae-tok', client: 'trae' });
+
+    const content = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+    expect(content.mcpServers.yuque).toBeDefined();
+  });
+
+  it('should merge into vscode config with existing servers', () => {
+    const configPath = path.join(tmpDir, 'vscode-merge', 'mcp.json');
+    fs.mkdirSync(path.dirname(configPath), { recursive: true });
+    fs.writeFileSync(
+      configPath,
+      JSON.stringify(
+        {
+          servers: {
+            'github-copilot': {
+              command: 'gh-copilot',
+              args: ['serve'],
+            },
+          },
+        },
+        null,
+        2
+      ),
+      'utf-8'
+    );
+
+    mockConfigPath('vscode', configPath);
+    installToClient({ token: 'vsc-merge-tok', client: 'vscode' });
+
+    const content = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+    // Original server preserved
+    expect(content.servers['github-copilot']).toBeDefined();
+    // Yuque added under 'servers' (not 'mcpServers')
+    expect(content.servers['yuque']).toBeDefined();
+    expect(content.servers['yuque'].env.YUQUE_PERSONAL_TOKEN).toBe('vsc-merge-tok');
+    // No mcpServers key should exist
+    expect(content.mcpServers).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Add `npx yuque-mcp install` and `npx yuque-mcp setup` CLI commands so users can configure their MCP clients without manually editing JSON config files.

## Usage

### One-line install
```bash
npx yuque-mcp install --token=YOUR_TOKEN --client=cursor
```

### Interactive setup wizard
```bash
npx yuque-mcp setup
```

## Supported Clients

| Client | Config Key | Platform Support |
|--------|-----------|-----------------|
| `claude-desktop` | `mcpServers` | macOS, Windows, Linux |
| `vscode` | `servers` | All (workspace-level) |
| `cursor` | `mcpServers` | All |
| `windsurf` | `mcpServers` | All |
| `cline` | `mcpServers` | macOS, Windows, Linux |
| `trae` | `mcpServers` | macOS, Windows, Linux |

## Key Features

- **Zero new dependencies** — uses only Node.js built-in modules (`fs`, `path`, `os`, `readline`)
- **Safe merging** — reads existing config files and preserves other server entries
- **VS Code aware** — correctly uses `servers` key instead of `mcpServers`
- **Cross-platform** — resolves correct config paths for macOS, Windows, and Linux
- **Error handling** — creates parent directories, backs up invalid JSON, shows helpful messages
- **Non-breaking** — `install`/`setup` subcommands are intercepted before MCP server starts; existing functionality is unchanged

## Changes

- `src/cli-install.ts` — new file with all install/setup logic
- `src/cli.ts` — modified to intercept subcommands before server startup
- `tests/cli-install.test.ts` — 17 tests covering all clients, merging, updating, and edge cases
- `README.md` — added Quick Install section
- `README.zh-CN.md` — added Quick Install section (Chinese)

## Tests

All 74 tests pass (57 existing + 17 new). Build and lint clean.