### PR TITLE
fix: show helpful guide when run directly in terminal

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import { createRequire } from 'node:module';
 import { handleCliSubcommands } from './cli-install.js';
 import { runStdioServer } from './server.js';
 
@@ -17,6 +18,34 @@ if (handleCliSubcommands(process.argv)) {
   if (!token) {
     console.error('Error: YUQUE_PERSONAL_TOKEN, YUQUE_GROUP_TOKEN, or YUQUE_TOKEN environment variable (or --token argument) is required');
     process.exit(1);
+  }
+
+  // If running directly in a terminal (not piped by an MCP client),
+  // show a helpful guide instead of silently waiting on stdio.
+  if (process.stdin.isTTY) {
+    const require = createRequire(import.meta.url);
+    const { version } = require('../package.json');
+    console.log(`
+╔══════════════════════════════════════════════════════════════╗
+║  🍃 Yuque MCP Server v${version.padEnd(39)}║
+╚══════════════════════════════════════════════════════════════╝
+
+  ⚠️  MCP Server 需要通过 MCP 客户端启动，不能直接在终端运行。
+
+  🚀 快速安装到你的编辑器:
+
+    npx yuque-mcp install --client=vscode --token=YOUR_TOKEN
+    npx yuque-mcp install --client=cursor --token=YOUR_TOKEN
+
+  🔧 交互式引导安装:
+
+    npx yuque-mcp setup
+
+  📖 支持的客户端: vscode, cursor, windsurf, claude-desktop, trae, cline
+
+  🔗 更多信息: https://github.com/yuque/yuque-mcp-server
+`);
+    process.exit(0);
   }
 
   runStdioServer(token).catch((error) => {


### PR DESCRIPTION
## Problem

Users following our tutorial run `npx yuque-mcp` directly in their terminal and see:

```
Yuque MCP Server running on stdio
```

The process appears to hang, and users don't know what to do next. This is because MCP Server expects to be launched by an MCP client via stdio, not run interactively.

## Solution

Detect when the process is running in a TTY (interactive terminal) via `process.stdin.isTTY`. When detected, show a friendly guide instead of entering stdio mode:

```
╔══════════════════════════════════════════════════════════════╗
║  🍃 Yuque MCP Server v0.1.4                                  ║
╚══════════════════════════════════════════════════════════════╝

  ⚠️  MCP Server 需要通过 MCP 客户端启动，不能直接在终端运行。

  🚀 快速安装到你的编辑器:

    npx yuque-mcp install --client=vscode --token=YOUR_TOKEN
    npx yuque-mcp install --client=cursor --token=YOUR_TOKEN

  🔧 交互式引导安装:

    npx yuque-mcp setup

  📖 支持的客户端: vscode, cursor, windsurf, claude-desktop, trae, cline

  🔗 更多信息: https://github.com/yuque/yuque-mcp-server
```

Non-TTY invocations (when piped by MCP clients like VS Code, Cursor, etc.) work exactly as before.

## Testing

- Build: ✅
- 74 tests: ✅
- TTY detection: verified locally with `YUQUE_TOKEN=test node dist/cli.js`