### PR TITLE
feat: auto-append doc to TOC on create and improve TOC tool descriptions

### DIFF
--- a/src/tools/doc.ts
+++ b/src/tools/doc.ts
@@ -2,6 +2,26 @@ import { z } from 'zod';
 import type { YuqueClient } from '../services/yuque-client.js';
 import { formatDocSummary, formatDoc } from '../utils/format.js';
 
+async function appendDocToToc(
+  client: YuqueClient,
+  repoId: string | number,
+  docId: number
+): Promise<string | null> {
+  try {
+    const tocData = JSON.stringify({
+      action: 'appendNode',
+      action_mode: 'child',
+      target_uuid: '',
+      type: 'DOC',
+      doc_id: docId,
+    });
+    await client.updateToc(repoId, tocData);
+    return null; // success
+  } catch {
+    return 'Document created successfully but failed to auto-append to TOC. Use yuque_update_toc to add it manually.';
+  }
+}
+
 export const docTools = {
   yuque_list_docs: {
     description: 'List all documents in a repo/book',
@@ -80,14 +100,17 @@ export const docTools = {
         public: args.public,
       };
       const doc = await client.createDoc(args.repo_id, data);
-      return {
-        content: [
-          {
-            type: 'text' as const,
-            text: JSON.stringify(formatDoc(doc), null, 2),
-          },
-        ],
-      };
+
+      // Auto-append to TOC
+      const tocWarning = await appendDocToToc(client, args.repo_id, doc.id);
+
+      const result: { type: 'text'; text: string }[] = [
+        { type: 'text' as const, text: JSON.stringify(formatDoc(doc), null, 2) },
+      ];
+      if (tocWarning) {
+        result.push({ type: 'text' as const, text: tocWarning });
+      }
+      return { content: result };
     },
   },
 

--- a/src/tools/toc.ts
+++ b/src/tools/toc.ts
@@ -24,12 +24,17 @@ export const tocTools = {
   },
 
   yuque_update_toc: {
-    description: 'Update the table of contents (TOC) for a repo/book',
+    description:
+      'Update the table of contents (TOC) for a repo/book. The toc_data must be a single-operation JSON object (not an array). Required fields: "action" (e.g. "appendNode"), "action_mode" ("child" or "sibling"), "target_uuid" (empty string for root level). For new nodes: include "type" ("TITLE" or "DOC") and "title". To move existing nodes: use "node_uuid" instead. Example: {"action":"appendNode","action_mode":"child","target_uuid":"","type":"TITLE","title":"New Section"}',
     inputSchema: z.object({
       repo_id: z
         .union([z.string(), z.number()])
         .describe('Repo ID or namespace (e.g., "mygroup/mybook")'),
-      toc_data: z.string().describe('TOC data as JSON string'),
+      toc_data: z
+        .string()
+        .describe(
+          'Single-operation JSON object. Must include "action" (e.g. "appendNode"), "action_mode" ("child"|"sibling"), "target_uuid" (empty string = root). For new nodes add "type"+"title"; to move existing nodes use "node_uuid".'
+        ),
     }),
     handler: async (client: YuqueClient, args: { repo_id: string | number; toc_data: string }) => {
       const toc = await client.updateToc(args.repo_id, args.toc_data);

--- a/tests/tools/doc.test.ts
+++ b/tests/tools/doc.test.ts
@@ -8,6 +8,7 @@ const mockClient = {
   createDoc: vi.fn(),
   updateDoc: vi.fn(),
   deleteDoc: vi.fn(),
+  updateToc: vi.fn(),
 } as unknown as YuqueClient;
 
 beforeEach(() => vi.clearAllMocks());
@@ -57,6 +58,32 @@ describe('docTools', () => {
       const parsed = JSON.parse(result.content[0].text);
       expect(parsed).toHaveProperty('title', 'New Doc');
       expect(mockClient.createDoc).toHaveBeenCalledWith(1, expect.objectContaining({ title: 'New Doc', body: 'Content' }));
+    });
+
+    it('should auto-append created doc to TOC', async () => {
+      (mockClient.createDoc as ReturnType<typeof vi.fn>).mockResolvedValue({
+        id: 2, slug: 'new-doc', title: 'New Doc', body: 'Content',
+        format: 'markdown', created_at: '2024-01-01', updated_at: '2024-01-01', word_count: 1,
+      });
+      (mockClient.updateToc as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+      const result = await docTools.yuque_create_doc.handler(mockClient, {
+        repo_id: 1, title: 'New Doc', body: 'Content',
+      } as never);
+      expect(mockClient.updateToc).toHaveBeenCalledWith(1, expect.stringContaining('"appendNode"'));
+      expect(result.content).toHaveLength(1); // no warning
+    });
+
+    it('should return warning when TOC append fails', async () => {
+      (mockClient.createDoc as ReturnType<typeof vi.fn>).mockResolvedValue({
+        id: 3, slug: 'doc3', title: 'Doc 3', body: '',
+        format: 'markdown', created_at: '2024-01-01', updated_at: '2024-01-01', word_count: 0,
+      });
+      (mockClient.updateToc as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('TOC error'));
+      const result = await docTools.yuque_create_doc.handler(mockClient, {
+        repo_id: 1, title: 'Doc 3',
+      } as never);
+      expect(result.content).toHaveLength(2); // doc + warning
+      expect(result.content[1].text).toContain('failed to auto-append to TOC');
     });
   });
 


### PR DESCRIPTION
## Summary

When creating a document via `yuque_create_doc`, it was not automatically added to the repository's table of contents (TOC). Users had to manually call `yuque_update_toc` as a separate step, which was unintuitive and error-prone.

## Changes

### 1. Auto-append to TOC on document creation (`src/tools/doc.ts`)
- Added `appendDocToToc` helper function that automatically appends newly created documents to the repo's TOC at root level
- On failure, returns a warning message instead of throwing, so the document creation itself is never lost
- The handler now returns an array of content items: the doc data, plus an optional warning if TOC append failed

### 2. Improved TOC tool descriptions (`src/tools/toc.ts`)
- Updated `yuque_update_toc` description with detailed parameter documentation and a usage example
- Updated `toc_data` parameter description to clarify the expected JSON format

### 3. Tests (`tests/tools/doc.test.ts`)
- Added test: successful TOC auto-append (no warning returned)
- Added test: TOC append failure returns warning message without breaking doc creation
- Added `updateToc` to mock client

All 76 tests pass. Lint and typecheck clean.

Fixes yuque/yuque-ecosystem#32
Fixes #11
Related #21