### PR TITLE
feat: add qoder and opencode client support for install command

### DIFF
--- a/src/cli-install.ts
+++ b/src/cli-install.ts
@@ -5,12 +5,14 @@ import * as readline from 'node:readline';
 
 // ─── Client Definitions ───────────────────────────────────────────────
 
-type ClientId = 'claude-desktop' | 'vscode' | 'cursor' | 'windsurf' | 'cline' | 'trae';
+type ClientId = 'claude-desktop' | 'vscode' | 'cursor' | 'windsurf' | 'cline' | 'trae' | 'qoder' | 'opencode';
 
 interface ClientConfig {
   name: string;
-  configKey: 'mcpServers' | 'servers';
+  configKey: 'mcpServers' | 'servers' | 'mcp';
   getConfigPath: () => string;
+  /** Custom function to build the server entry for this client (if different from the default). */
+  buildEntry?: (token: string) => Record<string, unknown>;
 }
 
 function getAppDataPath(): string {
@@ -125,6 +127,30 @@ const CLIENT_CONFIGS: Record<ClientId, ClientConfig> = {
       }
     },
   },
+  qoder: {
+    name: 'Qoder',
+    configKey: 'mcpServers',
+    getConfigPath() {
+      return path.join(os.homedir(), '.qoder', 'mcp.json');
+    },
+  },
+  opencode: {
+    name: 'OpenCode',
+    configKey: 'mcp',
+    getConfigPath() {
+      return path.join(process.cwd(), 'opencode.json');
+    },
+    buildEntry(token: string) {
+      return {
+        type: 'local',
+        command: ['npx', '-y', 'yuque-mcp'],
+        environment: {
+          YUQUE_PERSONAL_TOKEN: token,
+        },
+        enabled: true,
+      };
+    },
+  },
 };
 
 // ─── Config Generation ────────────────────────────────────────────────
@@ -191,7 +217,9 @@ export function installToClient(options: InstallOptions): string {
 
   // Inject/update the yuque entry
   const serversObj = config[configKey] as Record<string, unknown>;
-  serversObj['yuque'] = buildServerEntry(options.token);
+  serversObj['yuque'] = clientConfig.buildEntry
+    ? clientConfig.buildEntry(options.token)
+    : buildServerEntry(options.token);
 
   // Create parent directories if needed
   const dir = path.dirname(configPath);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -41,7 +41,7 @@ if (handleCliSubcommands(process.argv)) {
 
     npx yuque-mcp setup
 
-  📖 支持的客户端: vscode, cursor, windsurf, claude-desktop, trae, cline
+  📖 支持的客户端: vscode, cursor, windsurf, claude-desktop, trae, cline, qoder, opencode
 
   🔗 更多信息: https://github.com/yuque/yuque-mcp-server
 `);

--- a/tests/cli-install.test.ts
+++ b/tests/cli-install.test.ts
@@ -25,7 +25,7 @@ function mockConfigPath(client: string, configPath: string) {
 }
 
 describe('getSupportedClients', () => {
-  it('should return all 6 supported clients', () => {
+  it('should return all 8 supported clients', () => {
     const clients = getSupportedClients();
     expect(clients).toContain('claude-desktop');
     expect(clients).toContain('vscode');
@@ -33,7 +33,9 @@ describe('getSupportedClients', () => {
     expect(clients).toContain('windsurf');
     expect(clients).toContain('cline');
     expect(clients).toContain('trae');
-    expect(clients.length).toBe(6);
+    expect(clients).toContain('qoder');
+    expect(clients).toContain('opencode');
+    expect(clients.length).toBe(8);
   });
 });
 
@@ -269,6 +271,81 @@ describe('installToClient', () => {
 
     const content = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
     expect(content.mcpServers.yuque).toBeDefined();
+  });
+
+  it('should work for qoder client', () => {
+    const configPath = path.join(tmpDir, 'qoder', 'mcp.json');
+    mockConfigPath('qoder', configPath);
+
+    installToClient({ token: 'qoder-tok', client: 'qoder' });
+
+    const content = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+    expect(content.mcpServers.yuque).toBeDefined();
+    expect(content.mcpServers.yuque.command).toBe('npx');
+    expect(content.mcpServers.yuque.env.YUQUE_PERSONAL_TOKEN).toBe('qoder-tok');
+  });
+
+  it('should work for opencode client with custom format', () => {
+    const configPath = path.join(tmpDir, 'opencode', 'opencode.json');
+    mockConfigPath('opencode', configPath);
+
+    installToClient({ token: 'opencode-tok', client: 'opencode' });
+
+    const content = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+    expect(content.mcp.yuque).toBeDefined();
+    expect(content.mcp.yuque).toEqual({
+      type: 'local',
+      command: ['npx', '-y', 'yuque-mcp'],
+      environment: {
+        YUQUE_PERSONAL_TOKEN: 'opencode-tok',
+      },
+      enabled: true,
+    });
+    // Should NOT have mcpServers key
+    expect(content.mcpServers).toBeUndefined();
+  });
+
+  it('should merge opencode config with existing settings', () => {
+    const configPath = path.join(tmpDir, 'opencode-merge', 'opencode.json');
+    fs.mkdirSync(path.dirname(configPath), { recursive: true });
+    fs.writeFileSync(
+      configPath,
+      JSON.stringify(
+        {
+          '$schema': 'https://opencode.ai/config.json',
+          model: 'anthropic/claude-sonnet-4-5',
+          mcp: {
+            'other-server': {
+              type: 'local',
+              command: ['npx', '-y', 'other-mcp'],
+              enabled: true,
+            },
+          },
+        },
+        null,
+        2
+      ),
+      'utf-8'
+    );
+
+    mockConfigPath('opencode', configPath);
+    installToClient({ token: 'oc-merge-tok', client: 'opencode' });
+
+    const content = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+    // Existing settings preserved
+    expect(content['$schema']).toBe('https://opencode.ai/config.json');
+    expect(content.model).toBe('anthropic/claude-sonnet-4-5');
+    // Existing MCP server preserved
+    expect(content.mcp['other-server']).toBeDefined();
+    // Yuque added
+    expect(content.mcp.yuque).toEqual({
+      type: 'local',
+      command: ['npx', '-y', 'yuque-mcp'],
+      environment: {
+        YUQUE_PERSONAL_TOKEN: 'oc-merge-tok',
+      },
+      enabled: true,
+    });
   });
 
   it('should merge into vscode config with existing servers', () => {


### PR DESCRIPTION
## Summary

Add support for two new MCP clients in the `install` and `setup` CLI commands:

### Qoder
- **Config path**: `~/.qoder/mcp.json`
- **Format**: Standard `mcpServers` format (same as Cursor/Windsurf)
- Qoder is a VS Code-based AI IDE

### OpenCode
- **Config path**: `opencode.json` (project-level)
- **Format**: OpenCode's own MCP config format with `mcp` key:
  ```json
  {
    "mcp": {
      "yuque": {
        "type": "local",
        "command": ["npx", "-y", "yuque-mcp"],
        "environment": { "YUQUE_PERSONAL_TOKEN": "..." },
        "enabled": true
      }
    }
  }
  ```
- Ref: [OpenCode MCP docs](https://opencode.ai/docs/mcp-servers)

### Changes
- `src/cli-install.ts`: Added `qoder` and `opencode` to `ClientId` type and `CLIENT_CONFIGS`. Added support for custom `buildEntry` per client to handle non-standard config formats.
- `src/cli.ts`: Updated help text to list new clients.
- `tests/cli-install.test.ts`: Added 4 new tests (qoder basic, opencode format, opencode merge).

All 79 tests pass. ✅

Closes #20