### PR TITLE
feat: add yuque notes (小记) support (#22)

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -14,6 +14,7 @@ import { searchTools } from './tools/search.js';
 import { groupTools } from './tools/group.js';
 import { statsTools } from './tools/stats.js';
 import { versionTools } from './tools/version.js';
+import { noteTools } from './tools/note.js';
 
 export function createServer(token: string) {
   const client = new YuqueClient(token);
@@ -39,6 +40,7 @@ export function createServer(token: string) {
     ...groupTools,
     ...statsTools,
     ...versionTools,
+    ...noteTools,
   };
 
   // Register list_tools handler

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -181,3 +181,55 @@ export interface UpdateDocData {
   body?: string;
   public?: number;
 }
+// 添加到 src/services/types.ts 的小记类型定义
+
+export interface YuqueNoteContent {
+  updated_at: string;
+  abstract: string;
+  format?: string;
+  source?: string;
+  html?: string;
+  draft_version?: number;
+  doc_dynamic_data?: any[];
+}
+
+export interface YuqueNote {
+  id: number;
+  slug: string;
+  doclet_id: number;
+  user_id: number;
+  content: YuqueNoteContent;
+  published_at: string;
+  created_at: string;
+  updated_at: string;
+  deleted_at: string | null;
+  pinned_at: string | null;
+  status: number;
+  save_from: string | null;
+  public: number;
+  likes_count: number;
+  comments_count: number;
+  has_image: boolean;
+  has_attachment: boolean;
+  has_bookmark: boolean;
+  word_count: number;
+  tags: string[];
+  share_expired_time: string | null;
+}
+
+export interface YuqueNotesResponse {
+  pin_notes: YuqueNote[];
+  notes: YuqueNote[];
+  has_more: boolean;
+}
+
+export interface CreateNoteData {
+  body: string;
+}
+
+export interface UpdateNoteData {
+  source: string;
+  html: string;
+  abstract: string;
+  status?: number;
+}

--- a/src/services/yuque-client.ts
+++ b/src/services/yuque-client.ts
@@ -14,6 +14,10 @@ import type {
   UpdateRepoData,
   CreateDocData,
   UpdateDocData,
+  YuqueNote,
+  YuqueNotesResponse,
+  CreateNoteData,
+  UpdateNoteData,
 } from './types.js';
 import { handleYuqueError } from '../utils/error.js';
 
@@ -274,6 +278,69 @@ export class YuqueClient {
     return withErrorHandling(async () => {
       const r = await this.client.get<YuqueApiResponse<{ message: string }>>('/hello');
       return r.data.data;
+    });
+  }
+
+  // ── Note APIs ──────────────────────────────────────────────
+
+  /** List all notes (小记) for the current user. */
+  async listNotes(status?: number): Promise<YuqueNotesResponse> {
+    return withErrorHandling(async () => {
+      const params = status !== undefined ? { status } : {};
+      const r = await this.client.get<YuqueApiResponse<YuqueNotesResponse>>('/notes', { params });
+      return r.data.data;
+    });
+  }
+
+  /** Get a specific note by ID. */
+  async getNote(noteId: number): Promise<YuqueNote> {
+    return withErrorHandling(async () => {
+      const r = await this.client.get<YuqueApiResponse<YuqueNote>>(`/notes/${noteId}`);
+      return r.data.data;
+    });
+  }
+
+  /** Create a new note. */
+  async createNote(data: CreateNoteData): Promise<{ note_url: string }> {
+    return withErrorHandling(async () => {
+      const r = await this.client.post<{ success: boolean; data: { note_url: string } }>('/notes', data);
+      return r.data.data;
+    });
+  }
+
+  /** Update an existing note. */
+  async updateNote(noteId: number, data: UpdateNoteData): Promise<YuqueNote> {
+    return withErrorHandling(async () => {
+      const r = await this.client.put<{ data: { data: YuqueNote } }>(`/notes/${noteId}`, data);
+      return r.data.data.data;
+    });
+  }
+
+  /** Delete a note (move to trash). */
+  async deleteNote(noteId: number): Promise<void> {
+    return withErrorHandling(async () => {
+      const note = await this.getNote(noteId);
+      const data: UpdateNoteData = {
+        source: note.content.source || '',
+        html: note.content.html || '',
+        abstract: note.content.abstract || '',
+        status: 9,
+      };
+      await this.client.put(`/notes/${noteId}`, data);
+    });
+  }
+
+  /** Restore a note from trash. */
+  async restoreNote(noteId: number): Promise<void> {
+    return withErrorHandling(async () => {
+      const note = await this.getNote(noteId);
+      const data: UpdateNoteData = {
+        source: note.content.source || '',
+        html: note.content.html || '',
+        abstract: note.content.abstract || '',
+        status: 0,
+      };
+      await this.client.put(`/notes/${noteId}`, data);
     });
   }
 }

--- a/src/tools/note.ts
+++ b/src/tools/note.ts
@@ -1,0 +1,179 @@
+import { z } from 'zod';
+import type { YuqueClient } from '../services/yuque-client.js';
+import type { YuqueNote } from '../services/types.js';
+
+/** Format note summary — excludes full content to reduce token usage. */
+function formatNoteSummary(note: YuqueNote) {
+  return {
+    id: note.id,
+    slug: note.slug,
+    content_preview: note.content?.abstract?.replace(/<[^>]*>/g, '').substring(0, 100) || '',
+    word_count: note.word_count,
+    tags: note.tags,
+    created_at: note.created_at,
+    updated_at: note.updated_at,
+    is_pinned: !!note.pinned_at,
+    status: note.status,
+  };
+}
+
+/** Format full note data including content. */
+function formatNote(note: YuqueNote) {
+  return {
+    id: note.id,
+    slug: note.slug,
+    content: {
+      text: note.content?.source || note.content?.abstract || '',
+      html: note.content?.html || '',
+    },
+    word_count: note.word_count,
+    tags: note.tags,
+    created_at: note.created_at,
+    updated_at: note.updated_at,
+    published_at: note.published_at,
+    is_pinned: !!note.pinned_at,
+    likes_count: note.likes_count,
+    comments_count: note.comments_count,
+    status: note.status,
+  };
+}
+
+/** Convert plain text to Yuque Lake format (XML-like rich text format). */
+function textToLakeFormat(text: string): { source: string; html: string; abstract: string } {
+  const escapedText = text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+  return {
+    source: `<!doctype lake><meta name="doc-version" content="1" /><meta name="viewport" content="fixed" /><meta name="typography" content="classic" /><p><span>${escapedText}</span></p>`,
+    html: `<!doctype html><div class="lake-content"><p><span>${escapedText}</span></p></div>`,
+    abstract: `<!doctype lake><meta name="doc-version" content="1" /><p><span>${escapedText}</span></p>`,
+  };
+}
+
+export const noteTools = {
+  yuque_list_notes: {
+    description: 'List all notes (小记) for the current user',
+    inputSchema: z.object({
+      status: z.number().optional().describe('Filter by status: 0 (normal), 9 (deleted)'),
+    }),
+    handler: async (client: YuqueClient, args: { status?: number }) => {
+      const result = await client.listNotes(args.status);
+      const allNotes = [...result.pin_notes, ...result.notes];
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: JSON.stringify(
+              {
+                total: allNotes.length,
+                pinned: result.pin_notes.length,
+                has_more: result.has_more,
+                notes: allNotes.map(formatNoteSummary),
+              },
+              null,
+              2
+            ),
+          },
+        ],
+      };
+    },
+  },
+
+  yuque_get_note: {
+    description: 'Get a specific note with full content',
+    inputSchema: z.object({
+      note_id: z.number().describe('Note ID'),
+    }),
+    handler: async (client: YuqueClient, args: { note_id: number }) => {
+      const note = await client.getNote(args.note_id);
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: JSON.stringify(formatNote(note), null, 2),
+          },
+        ],
+      };
+    },
+  },
+
+  yuque_create_note: {
+    description: 'Create a new note (小记)',
+    inputSchema: z.object({
+      body: z.string().describe('Note content (plain text or markdown)'),
+    }),
+    handler: async (client: YuqueClient, args: { body: string }) => {
+      const result = await client.createNote({ body: args.body });
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: JSON.stringify(
+              {
+                success: true,
+                note_url: result.note_url,
+                message: 'Note created successfully',
+              },
+              null,
+              2
+            ),
+          },
+        ],
+      };
+    },
+  },
+
+  yuque_update_note: {
+    description: 'Update an existing note',
+    inputSchema: z.object({
+      note_id: z.number().describe('Note ID'),
+      body: z.string().describe('New note content (plain text)'),
+    }),
+    handler: async (client: YuqueClient, args: { note_id: number; body: string }) => {
+      const lakeFormat = textToLakeFormat(args.body);
+      const note = await client.updateNote(args.note_id, lakeFormat);
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: JSON.stringify(formatNote(note), null, 2),
+          },
+        ],
+      };
+    },
+  },
+
+  yuque_delete_note: {
+    description: 'Delete a note (move to trash)',
+    inputSchema: z.object({
+      note_id: z.number().describe('Note ID'),
+    }),
+    handler: async (client: YuqueClient, args: { note_id: number }) => {
+      await client.deleteNote(args.note_id);
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: 'Note deleted successfully (moved to trash)',
+          },
+        ],
+      };
+    },
+  },
+
+  yuque_restore_note: {
+    description: 'Restore a note from trash',
+    inputSchema: z.object({
+      note_id: z.number().describe('Note ID'),
+    }),
+    handler: async (client: YuqueClient, args: { note_id: number }) => {
+      await client.restoreNote(args.note_id);
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: 'Note restored successfully',
+          },
+        ],
+      };
+    },
+  },
+};


### PR DESCRIPTION
## 功能说明

实现语雀小记（Notes）的完整 MCP 能力支持，解决 issue #22

## 新增功能

- ✅ `yuque_list_notes` - 列出所有小记（支持status过滤）
- ✅ `yuque_get_note` - 获取单个小记详情
- ✅ `yuque_create_note` - 创建新小记
- ✅ `yuque_update_note` - 更新小记内容
- ✅ `yuque_delete_note` - 删除小记（移到回收站）
- ✅ `yuque_restore_note` - 从回收站恢复小记

## 修改文件

- `src/tools/note.ts` - 新增小记工具
- `src/services/yuque-client.ts` - 添加小记API方法
- `src/services/types.ts` - 添加小记类型定义
- `src/server.ts` - 注册小记工具

## 测试

所有功能已通过测试验证：
- 创建、列出、获取、更新、删除、恢复功能正常
- 代码风格符合项目规范
- TypeScript编译通过

Closes #22