### PR TITLE
fix: prevent phantom nodes by removing broken auto-append to TOC

### DIFF
--- a/src/tools/doc.ts
+++ b/src/tools/doc.ts
@@ -2,25 +2,6 @@ import { z } from 'zod';
 import type { YuqueClient } from '../services/yuque-client.js';
 import { formatDocSummary, formatDoc } from '../utils/format.js';
 
-async function appendDocToToc(
-  client: YuqueClient,
-  repoId: string | number,
-  docId: number
-): Promise<string | null> {
-  try {
-    const tocData = JSON.stringify({
-      action: 'appendNode',
-      action_mode: 'child',
-      target_uuid: '',
-      type: 'DOC',
-      doc_id: docId,
-    });
-    await client.updateToc(repoId, tocData);
-    return null; // success
-  } catch {
-    return 'Document created successfully but failed to auto-append to TOC. Use yuque_update_toc to add it manually.';
-  }
-}
 
 export const docTools = {
   yuque_list_docs: {
@@ -99,17 +80,12 @@ export const docTools = {
         format: args.format,
         public: args.public,
       };
-      const doc = await client.createDoc(args.repo_id, data);
-
-      // Auto-append to TOC
-      const tocWarning = await appendDocToToc(client, args.repo_id, doc.id);
+            const doc = await client.createDoc(args.repo_id, data);
 
       const result: { type: 'text'; text: string }[] = [
         { type: 'text' as const, text: JSON.stringify(formatDoc(doc), null, 2) },
+        { type: 'text' as const, text: 'Note: The document has been created successfully but is currently uncatalogued (未编排文档). Due to Yuque OpenAPI limitations that create broken phantom nodes, automatic TOC appending has been disabled. Please manually drag it into your desired TOC location via the Yuque Web UI.' }
       ];
-      if (tocWarning) {
-        result.push({ type: 'text' as const, text: tocWarning });
-      }
       return { content: result };
     },
   },


### PR DESCRIPTION
fix: remove broken auto-append to TOC in `create_doc` tool

### Context & Background
Currently, the `yuque_create_doc` tool attempts to automatically append a newly created document to the repository's TOC using the Open API `PUT /api/v2/repos/:namespace/toc`. 

The original implementation uses:
```json
{
  "action": "appendNode",
  "action_mode": "child",
  "target_uuid": "",
  "type": "DOC",
  "doc_id": docId
}
```

### The Problem
However, according to Yuque's V2 OpenAPI constraints and extensive testing, sending this payload (or even simpler valid payloads like `{"action":"append", "doc_ids":[ID]}`) via the V2 API results in a **corrupted phantom node** in the user's document tree. 
Specifically:
1. The node is created but lacks the `title` and `url` attributes.
2. In the Yuque web UI, this appears as an unclickable "无标题" (Untitled) document with a `null` link.
3. The actual document content remains uncatalogued in the "未编排文档" section.
4. Calling `appendNode` directly can also trigger `422 Unprocessable Entity` or `400 missing action_mode` if parameters are not perfectly aligned with undocumented backend strict validations.

*Note: The only known way to perfectly append/prepend and bind the URL is using the undocumented private frontend API (`/api/catalog_nodes` with `x-csrf-token`), which is out of scope for an MCP server relying on the public OpenAPI token.*

### The Solution
Since the public V2 TOC API is fundamentally broken regarding new node URL binding, the safest and most user-friendly approach is to **remove the automatic, broken TOC append logic entirely**. 

This PR:
1. Removes the `appendDocToToc` helper function.
2. Removes the execution of this logic inside `yuque_create_doc`.
3. Returns a clean message that the document was created successfully but remains uncatalogued (leaving the TOC arrangement to the user via the Web UI).

This prevents the MCP server from polluting the user's workspace with undeletable phantom nodes.
