### PR TITLE
fix: add request timeout to prevent hanging on slow API responses

### DIFF
--- a/src/services/yuque-client.ts
+++ b/src/services/yuque-client.ts
@@ -39,6 +39,7 @@ export class YuqueClient {
   constructor(token: string, baseURL = 'https://www.yuque.com/api/v2') {
     this.client = axios.create({
       baseURL,
+      timeout: 30000,
       headers: {
         'X-Auth-Token': token,
         'Content-Type': 'application/json',


### PR DESCRIPTION
Fixes #32.

Adds a 30-second timeout to the axios client instance. Previously, requests with no timeout could hang indefinitely when the Yuque API is slow to respond, particularly for write operations (create_doc, update_doc).

This ensures that slow or unresponsive API calls will fail with a timeout error instead of blocking forever.