### PR TITLE
fix: add null safety to search results and improve MCP error handling

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -69,10 +69,11 @@ export function createServer(token: string) {
       // Call the tool handler
       return await tool.handler(client, args as never);
     } catch (error) {
-      if (error instanceof Error) {
-        throw new Error(`Tool execution failed: ${error.message}`);
-      }
-      throw error;
+      const message = error instanceof Error ? error.message : String(error);
+      return {
+        content: [{ type: 'text' as const, text: `Tool execution failed: ${message}` }],
+        isError: true,
+      };
     }
   });
 

--- a/src/tools/search.ts
+++ b/src/tools/search.ts
@@ -14,7 +14,7 @@ export const searchTools = {
         content: [
           {
             type: 'text' as const,
-            text: JSON.stringify(result, null, 2),
+            text: JSON.stringify(result ?? [], null, 2),
           },
         ],
       };


### PR DESCRIPTION
Fixes #54. Two changes:

1. Search handler now returns empty array when API returns null/undefined, preventing JSON.stringify(undefined)
2. Server error handler returns MCP-compliant error response instead of throwing, per MCP specification