### PR TITLE
ci: add runtime smoke validation gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,10 +9,13 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    env:
+      NPM_CONFIG_CACHE: ${{ runner.temp }}/npm-cache
+      YUQUE_MCP_SMOKE_NPM_CACHE: ${{ runner.temp }}/npm-cache
 
     strategy:
       matrix:
-        node-version: [18.x, 20.x, 22.x]
+        node-version: [18.x, 20.x, 22.x, 24.x]
 
     steps:
     - uses: actions/checkout@v4
@@ -38,8 +41,17 @@ jobs:
     - name: Build
       run: npm run build
 
+    - name: Run dist CLI smoke test
+      run: npm run smoke:dist
+
+    - name: Run packed install smoke test
+      run: npm run smoke:pack-install
+
   coverage:
     runs-on: ubuntu-latest
+    env:
+      NPM_CONFIG_CACHE: ${{ runner.temp }}/npm-cache
+      YUQUE_MCP_SMOKE_NPM_CACHE: ${{ runner.temp }}/npm-cache
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,9 +9,6 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    env:
-      NPM_CONFIG_CACHE: ${{ runner.temp }}/npm-cache
-      YUQUE_MCP_SMOKE_NPM_CACHE: ${{ runner.temp }}/npm-cache
 
     strategy:
       matrix:
@@ -25,6 +22,11 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
+
+    - name: Configure npm cache paths
+      run: |
+        echo "NPM_CONFIG_CACHE=$RUNNER_TEMP/npm-cache" >> "$GITHUB_ENV"
+        echo "YUQUE_MCP_SMOKE_NPM_CACHE=$RUNNER_TEMP/npm-cache" >> "$GITHUB_ENV"
 
     - name: Install dependencies
       run: npm ci
@@ -49,9 +51,6 @@ jobs:
 
   coverage:
     runs-on: ubuntu-latest
-    env:
-      NPM_CONFIG_CACHE: ${{ runner.temp }}/npm-cache
-      YUQUE_MCP_SMOKE_NPM_CACHE: ${{ runner.temp }}/npm-cache
 
     steps:
     - uses: actions/checkout@v4
@@ -61,6 +60,11 @@ jobs:
       with:
         node-version: '20.x'
         cache: 'npm'
+
+    - name: Configure npm cache paths
+      run: |
+        echo "NPM_CONFIG_CACHE=$RUNNER_TEMP/npm-cache" >> "$GITHUB_ENV"
+        echo "YUQUE_MCP_SMOKE_NPM_CACHE=$RUNNER_TEMP/npm-cache" >> "$GITHUB_ENV"
 
     - name: Install dependencies
       run: npm ci

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,6 +10,9 @@ jobs:
     permissions:
       contents: read
       id-token: write
+    env:
+      NPM_CONFIG_CACHE: ${{ runner.temp }}/npm-cache
+      YUQUE_MCP_SMOKE_NPM_CACHE: ${{ runner.temp }}/npm-cache
 
     steps:
     - uses: actions/checkout@v4
@@ -31,6 +34,9 @@ jobs:
 
     - name: Build
       run: npm run build
+
+    - name: Run packed install smoke test
+      run: npm run smoke:pack-install
 
     - name: Publish to npm (Trusted Publishing)
       run: npm publish --provenance --access public

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,9 +10,6 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    env:
-      NPM_CONFIG_CACHE: ${{ runner.temp }}/npm-cache
-      YUQUE_MCP_SMOKE_NPM_CACHE: ${{ runner.temp }}/npm-cache
 
     steps:
     - uses: actions/checkout@v4
@@ -22,6 +19,11 @@ jobs:
       with:
         node-version: '24.x'
         cache: 'npm'
+
+    - name: Configure npm cache paths
+      run: |
+        echo "NPM_CONFIG_CACHE=$RUNNER_TEMP/npm-cache" >> "$GITHUB_ENV"
+        echo "YUQUE_MCP_SMOKE_NPM_CACHE=$RUNNER_TEMP/npm-cache" >> "$GITHUB_ENV"
 
     - name: Configure npm registry for Trusted Publishing
       run: npm config set registry https://registry.npmjs.org/

--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
   "scripts": {
     "build": "tsc && chmod +x dist/cli.js",
     "dev": "tsx watch src/cli.ts",
+    "smoke:dist": "node scripts/smoke-dist-cli.js",
+    "smoke:pack-install": "node scripts/smoke-packed-install.js",
     "test": "vitest",
     "test:coverage": "vitest --coverage",
     "lint": "eslint src tests",

--- a/scripts/cli-smoke-utils.js
+++ b/scripts/cli-smoke-utils.js
@@ -1,0 +1,88 @@
+import { spawn } from 'node:child_process';
+import { access } from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+
+export const EXPECTED_MISSING_TOKEN_MESSAGE =
+  'Error: YUQUE_PERSONAL_TOKEN environment variable or --token argument is required';
+
+const DEFAULT_TIMEOUT_MS = 5000;
+
+function formatStream(name, content) {
+  const normalized = content.trim();
+  return `${name}:\n${normalized || '(empty)'}`;
+}
+
+export async function assertCliStartsAndFailsWithoutToken(
+  cliPath,
+  { cwd = path.dirname(cliPath), label = cliPath, timeoutMs = DEFAULT_TIMEOUT_MS } = {}
+) {
+  await access(cliPath);
+
+  const child = spawn(process.execPath, [ cliPath ], {
+    cwd,
+    env: {
+      ...process.env,
+      YUQUE_PERSONAL_TOKEN: '',
+    },
+    stdio: [ 'pipe', 'pipe', 'pipe' ],
+  });
+
+  child.stdin.end();
+
+  let stdout = '';
+  let stderr = '';
+  let timedOut = false;
+
+  child.stdout.setEncoding('utf8');
+  child.stderr.setEncoding('utf8');
+  child.stdout.on('data', chunk => {
+    stdout += chunk;
+  });
+  child.stderr.on('data', chunk => {
+    stderr += chunk;
+  });
+
+  const result = await new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      timedOut = true;
+      child.kill('SIGKILL');
+    }, timeoutMs);
+
+    child.once('error', error => {
+      clearTimeout(timeout);
+      reject(error);
+    });
+
+    child.once('close', (code, signal) => {
+      clearTimeout(timeout);
+      resolve({ code, signal });
+    });
+  });
+
+  if (timedOut) {
+    throw new Error(
+      `${label} timed out after ${timeoutMs}ms while validating CLI startup.\n` +
+        `${formatStream('stdout', stdout)}\n${formatStream('stderr', stderr)}`
+    );
+  }
+
+  if (result.signal) {
+    throw new Error(
+      `${label} exited via unexpected signal ${result.signal}.\n` +
+        `${formatStream('stdout', stdout)}\n${formatStream('stderr', stderr)}`
+    );
+  }
+
+  if (result.code !== 1 || !stderr.includes(EXPECTED_MISSING_TOKEN_MESSAGE)) {
+    const importFailure = stderr.includes('ERR_IMPORT_ATTRIBUTE_MISSING')
+      ? '\nDetected runtime module loading failure before CLI argument validation.'
+      : '';
+    throw new Error(
+      `${label} did not reach the expected missing-token failure path.` +
+        `${importFailure}\nExpected exit code: 1\nActual exit code: ${result.code}\n` +
+        `Expected stderr to include:\n${EXPECTED_MISSING_TOKEN_MESSAGE}\n` +
+        `${formatStream('stdout', stdout)}\n${formatStream('stderr', stderr)}`
+    );
+  }
+}

--- a/scripts/smoke-dist-cli.js
+++ b/scripts/smoke-dist-cli.js
@@ -1,0 +1,14 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { assertCliStartsAndFailsWithoutToken } from './cli-smoke-utils.js';
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(scriptDir, '..');
+const cliPath = path.join(repoRoot, 'dist', 'cli.js');
+
+await assertCliStartsAndFailsWithoutToken(cliPath, {
+  cwd: repoRoot,
+  label: 'dist CLI smoke test',
+});
+
+console.log(`dist CLI smoke test passed: ${cliPath}`);

--- a/scripts/smoke-packed-install.js
+++ b/scripts/smoke-packed-install.js
@@ -1,0 +1,175 @@
+import { spawn } from 'node:child_process';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { assertCliStartsAndFailsWithoutToken } from './cli-smoke-utils.js';
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(scriptDir, '..');
+
+function buildCleanEnv(extraEnv = {}) {
+  const env = {};
+
+  for (const [ key, value ] of Object.entries(process.env)) {
+    if (key.startsWith('npm_') || key.startsWith('NPM_')) {
+      continue;
+    }
+    env[key] = value;
+  }
+
+  return {
+    ...env,
+    ...extraEnv,
+  };
+}
+
+function resolveNpmCache(tempRoot) {
+  return process.env.YUQUE_MCP_SMOKE_NPM_CACHE || path.join(tempRoot, 'npm-cache');
+}
+
+function getNpmCommand(args) {
+  if (process.env.npm_execpath) {
+    return {
+      command: process.execPath,
+      args: [ process.env.npm_execpath, ...args ],
+    };
+  }
+
+  return {
+    command: 'npm',
+    args,
+  };
+}
+
+async function runCommand(command, args, { cwd, env, label, timeoutMs = 120000 }) {
+  const child = spawn(command, args, {
+    cwd,
+    env,
+    stdio: [ 'ignore', 'pipe', 'pipe' ],
+  });
+
+  let stdout = '';
+  let stderr = '';
+  let timedOut = false;
+
+  child.stdout.setEncoding('utf8');
+  child.stderr.setEncoding('utf8');
+  child.stdout.on('data', chunk => {
+    stdout += chunk;
+  });
+  child.stderr.on('data', chunk => {
+    stderr += chunk;
+  });
+
+  const result = await new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      timedOut = true;
+      child.kill('SIGKILL');
+    }, timeoutMs);
+
+    child.once('error', error => {
+      clearTimeout(timeout);
+      reject(error);
+    });
+
+    child.once('close', (code, signal) => {
+      clearTimeout(timeout);
+      resolve({ code, signal });
+    });
+  });
+
+  if (timedOut) {
+    throw new Error(
+      `${label} timed out after ${timeoutMs}ms.\nstdout:\n${stdout.trim() || '(empty)'}\n` +
+        `stderr:\n${stderr.trim() || '(empty)'}`
+    );
+  }
+
+  if (result.code !== 0 || result.signal) {
+    throw new Error(
+      `${label} failed with code ${result.code}${result.signal ? ` and signal ${result.signal}` : ''}.\n` +
+        `stdout:\n${stdout.trim() || '(empty)'}\nstderr:\n${stderr.trim() || '(empty)'}`
+    );
+  }
+
+  return { stdout, stderr };
+}
+
+async function main() {
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), 'yuque-mcp-pack-smoke-'));
+  const packDir = path.join(tempRoot, 'pack');
+  const installDir = path.join(tempRoot, 'install');
+  const npmCache = resolveNpmCache(tempRoot);
+  const npmEnv = buildCleanEnv({
+    npm_config_cache: npmCache,
+    NPM_CONFIG_CACHE: npmCache,
+  });
+
+  try {
+    await mkdir(packDir, { recursive: true });
+    await mkdir(installDir, { recursive: true });
+
+    const packCommand = getNpmCommand([ 'pack', '--json', '--cache', npmCache, repoRoot ]);
+    const packResult = await runCommand(packCommand.command, packCommand.args, {
+      cwd: packDir,
+      env: npmEnv,
+      label: 'npm pack',
+    });
+
+    const packInfo = JSON.parse(packResult.stdout);
+    if (!Array.isArray(packInfo) || packInfo.length === 0 || !packInfo[0]?.filename) {
+      throw new Error(`npm pack returned unexpected JSON:\n${packResult.stdout}`);
+    }
+
+    const tarballPath = path.join(packDir, packInfo[0].filename);
+
+    await writeFile(
+      path.join(installDir, 'package.json'),
+      JSON.stringify({ name: 'yuque-mcp-pack-smoke', private: true }, null, 2) + '\n',
+      'utf8'
+    );
+
+    const installCommand = getNpmCommand([
+      'install',
+      '--cache',
+      npmCache,
+      '--prefer-offline',
+      '--fetch-retries',
+      '0',
+      '--fetch-timeout',
+      '30000',
+      '--ignore-scripts',
+      '--no-package-lock',
+      tarballPath,
+    ]);
+
+    await runCommand(installCommand.command, installCommand.args, {
+      cwd: installDir,
+      env: npmEnv,
+      label: 'npm install tarball',
+      timeoutMs: 60000,
+    });
+
+    const installedPackageJsonPath = path.join(installDir, 'node_modules', 'yuque-mcp', 'package.json');
+    const installedPackageJson = JSON.parse(await readFile(installedPackageJsonPath, 'utf8'));
+    const cliRelativePath = installedPackageJson.bin?.['yuque-mcp'];
+
+    if (typeof cliRelativePath !== 'string' || cliRelativePath.length === 0) {
+      throw new Error(`Installed package is missing a yuque-mcp bin entry: ${installedPackageJsonPath}`);
+    }
+
+    const installedCliPath = path.join(installDir, 'node_modules', 'yuque-mcp', cliRelativePath);
+
+    await assertCliStartsAndFailsWithoutToken(installedCliPath, {
+      cwd: installDir,
+      label: 'packed install CLI smoke test',
+    });
+
+    console.log(`packed install smoke test passed: ${tarballPath}`);
+  } finally {
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+}
+
+await main();


### PR DESCRIPTION
## Summary
- expand the CI matrix to Node.js 18.x, 20.x, 22.x, and 24.x
- add a dist CLI smoke test that verifies the built artifact reaches the expected missing-token failure path
- add a packed-install smoke test that runs `npm pack`, installs the tarball in a temp directory, and validates the installed CLI before publish
- run the packed-install smoke test in the publish workflow before `npm publish`

## Problem
Previously we could prove that the source compiled and tests passed, but we could not prove that the published artifact could actually start under the target Node.js runtime. That left a gap where ESM/runtime regressions could pass CI and only fail after release.

## Test plan
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run build`
- `npm run smoke:dist`
- `env -u https_proxy -u http_proxy -u all_proxy -u HTTPS_PROXY -u HTTP_PROXY -u ALL_PROXY -u NO_PROXY -u no_proxy npm run smoke:pack-install`

Note: the local `smoke:pack-install` command was run without proxy environment variables because the current machine's local proxy settings blocked direct access to `registry.npmjs.org`. GitHub Actions will run the same validation in its normal network environment.
