### PR TITLE
Feat/custom base url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### ✨ Features
+
+- Support custom API base URL via `YUQUE_BASE_URL` env var or `--base-url` CLI arg for private deployments
+
 ### 🐞 Bug Fixes
 
 - Fix Node.js v24 compatibility by replacing ESM JSON import with createRequire (#52) (#52)

--- a/README.md
+++ b/README.md
@@ -201,6 +201,23 @@ The server supports multiple ways to provide your Yuque API token:
 
 **Priority order:** `YUQUE_PERSONAL_TOKEN` > `--token`
 
+### Private Deployment
+
+For privately deployed Yuque instances, set the `YUQUE_BASE_URL` environment variable or use the `--base-url` CLI argument:
+
+```bash
+# Environment variable
+export YUQUE_BASE_URL=https://yuque.example.com/api/v2
+
+# CLI argument
+npx yuque-mcp --token=YOUR_TOKEN --base-url=https://yuque.example.com/api/v2
+
+# Install with custom base URL
+npx yuque-mcp install --token=YOUR_TOKEN --client=cursor --base-url=https://yuque.example.com/api/v2
+```
+
+When not set, the default is `https://www.yuque.com/api/v2`.
+
 ---
 
 ## Available Tools (16)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -201,6 +201,23 @@ claude mcp add yuque-mcp -- npx -y yuque-mcp
 
 **优先级：** `YUQUE_PERSONAL_TOKEN` > `--token`
 
+### 私有化部署
+
+如果使用私有化部署的语雀实例，设置 `YUQUE_BASE_URL` 环境变量或使用 `--base-url` CLI 参数：
+
+```bash
+# 环境变量
+export YUQUE_BASE_URL=https://yuque.example.com/api/v2
+
+# CLI 参数
+npx yuque-mcp --token=YOUR_TOKEN --base-url=https://yuque.example.com/api/v2
+
+# 安装时指定
+npx yuque-mcp install --token=YOUR_TOKEN --client=cursor --base-url=https://yuque.example.com/api/v2
+```
+
+不设置时默认为 `https://www.yuque.com/api/v2`。
+
 ---
 
 ## 可用工具（16 个）

--- a/src/cli-install.ts
+++ b/src/cli-install.ts
@@ -12,7 +12,7 @@ interface ClientConfig {
   configKey: 'mcpServers' | 'servers' | 'mcp';
   getConfigPath: () => string;
   /** Custom function to build the server entry for this client (if different from the default). */
-  buildEntry?: (token: string) => Record<string, unknown>;
+  buildEntry?: (token: string, baseURL?: string) => Record<string, unknown>;
 }
 
 function getAppDataPath(): string {
@@ -140,13 +140,13 @@ const CLIENT_CONFIGS: Record<ClientId, ClientConfig> = {
     getConfigPath() {
       return path.join(process.cwd(), 'opencode.json');
     },
-    buildEntry(token: string) {
+    buildEntry(token: string, baseURL?: string) {
+      const env: Record<string, string> = { YUQUE_PERSONAL_TOKEN: token };
+      if (baseURL) env.YUQUE_BASE_URL = baseURL;
       return {
         type: 'local',
         command: ['npx', '-y', 'yuque-mcp'],
-        environment: {
-          YUQUE_PERSONAL_TOKEN: token,
-        },
+        environment: env,
         enabled: true,
       };
     },
@@ -155,13 +155,13 @@ const CLIENT_CONFIGS: Record<ClientId, ClientConfig> = {
 
 // ─── Config Generation ────────────────────────────────────────────────
 
-function buildServerEntry(token: string) {
+function buildServerEntry(token: string, baseURL?: string) {
+  const env: Record<string, string> = { YUQUE_PERSONAL_TOKEN: token };
+  if (baseURL) env.YUQUE_BASE_URL = baseURL;
   return {
     command: 'npx',
     args: ['-y', 'yuque-mcp'],
-    env: {
-      YUQUE_PERSONAL_TOKEN: token,
-    },
+    env,
   };
 }
 
@@ -170,6 +170,7 @@ function buildServerEntry(token: string) {
 export interface InstallOptions {
   token: string;
   client: ClientId;
+  baseURL?: string;
 }
 
 export function getSupportedClients(): ClientId[] {
@@ -218,8 +219,8 @@ export function installToClient(options: InstallOptions): string {
   // Inject/update the yuque entry
   const serversObj = config[configKey] as Record<string, unknown>;
   serversObj['yuque'] = clientConfig.buildEntry
-    ? clientConfig.buildEntry(options.token)
-    : buildServerEntry(options.token);
+    ? clientConfig.buildEntry(options.token, options.baseURL)
+    : buildServerEntry(options.token, options.baseURL);
 
   // Create parent directories if needed
   const dir = path.dirname(configPath);
@@ -236,23 +237,25 @@ export function installToClient(options: InstallOptions): string {
 export function runInstall(args: string[]): void {
   const tokenArg = args.find((a) => a.startsWith('--token='));
   const clientArg = args.find((a) => a.startsWith('--client='));
+  const baseURLArg = args.find((a) => a.startsWith('--base-url='));
 
   if (!tokenArg) {
     console.error('Error: --token=YOUR_TOKEN is required.');
-    console.error('Usage: npx yuque-mcp install --token=YOUR_TOKEN --client=CLIENT');
+    console.error('Usage: npx yuque-mcp install --token=YOUR_TOKEN --client=CLIENT [--base-url=URL]');
     console.error(`Supported clients: ${getSupportedClients().join(', ')}`);
     process.exit(1);
   }
 
   if (!clientArg) {
     console.error('Error: --client=CLIENT is required.');
-    console.error('Usage: npx yuque-mcp install --token=YOUR_TOKEN --client=CLIENT');
+    console.error('Usage: npx yuque-mcp install --token=YOUR_TOKEN --client=CLIENT [--base-url=URL]');
     console.error(`Supported clients: ${getSupportedClients().join(', ')}`);
     process.exit(1);
   }
 
   const token = tokenArg.split('=').slice(1).join('=');
   const client = clientArg.split('=').slice(1).join('=') as ClientId;
+  const baseURL = baseURLArg?.split('=').slice(1).join('=');
 
   if (!token) {
     console.error('Error: Token value cannot be empty.');
@@ -260,7 +263,7 @@ export function runInstall(args: string[]): void {
   }
 
   try {
-    const configPath = installToClient({ token, client });
+    const configPath = installToClient({ token, client, baseURL });
     const clientName = CLIENT_CONFIGS[client]?.name ?? client;
     console.log(`\n✅ Successfully configured yuque-mcp for ${clientName}!`);
     console.log(`   Config file: ${configPath}`);
@@ -321,9 +324,14 @@ export async function runSetup(): Promise<void> {
 
     const client = clients[idx];
 
-    // Step 3: Install
+    // Step 3: Ask for base URL (optional, for private deployments)
+    console.log('\nStep 3: Enter your Yuque API base URL (optional)');
+    console.log('   (Leave empty for https://www.yuque.com/api/v2)\n');
+    const baseURL = (await askQuestion(rl, '   Base URL: ')) || undefined;
+
+    // Step 4: Install
     console.log('');
-    const configPath = installToClient({ token, client });
+    const configPath = installToClient({ token, client, baseURL });
     const clientName = CLIENT_CONFIGS[client].name;
     console.log(`✅ Successfully configured yuque-mcp for ${clientName}!`);
     console.log(`   Config file: ${configPath}`);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -46,7 +46,11 @@ if (handleCliSubcommands(process.argv)) {
     process.exit(0);
   }
 
-  runStdioServer(token).catch((error) => {
+  const baseURL =
+    process.env.YUQUE_BASE_URL ||
+    process.argv.find((arg) => arg.startsWith('--base-url='))?.split('=')[1];
+
+  runStdioServer(token, baseURL).catch((error) => {
     console.error('Fatal error:', error);
     process.exit(1);
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,11 @@ if (!token) {
   process.exit(1);
 }
 
-const mcpServer = createMCPServer(token);
+const baseURL =
+  process.env.YUQUE_BASE_URL ||
+  process.argv.find((arg) => arg.startsWith('--base-url='))?.split('=')[1];
+
+const mcpServer = createMCPServer(token, baseURL);
 const transport = new StreamableHTTPServerTransport({
   sessionIdGenerator: () => randomUUID(),
 });

--- a/src/server.ts
+++ b/src/server.ts
@@ -19,8 +19,8 @@ const packageJson = require('../package.json');
 
 export const MCP_SERVER_VERSION = packageJson.version;
 
-export function createServer(token: string) {
-  const client = new YuqueClient(token);
+export function createServer(token: string, baseURL?: string) {
+  const client = new YuqueClient(token, baseURL);
   const server = new Server(
     {
       name: 'yuque-mcp',
@@ -80,8 +80,8 @@ export function createServer(token: string) {
   return server;
 }
 
-export async function runStdioServer(token: string) {
-  const server = createServer(token);
+export async function runStdioServer(token: string, baseURL?: string) {
+  const server = createServer(token, baseURL);
   const transport = new StdioServerTransport();
   await server.connect(transport);
   console.error('Yuque MCP Server running on stdio');

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -15,6 +15,11 @@ describe('createServer', () => {
     expect(MCP_SERVER_VERSION).toBe(packageJson.version);
   });
 
+  it('should create a server with custom base URL', () => {
+    const server = createServer('test-token', 'https://yuque.internal.com/api/v2');
+    expect(server).toBeDefined();
+  });
+
   it('should register all 16 tools', async () => {
     const server = createServer('test-token');
 

--- a/tests/services/yuque-client.test.ts
+++ b/tests/services/yuque-client.test.ts
@@ -20,6 +20,27 @@ describe('YuqueClient', () => {
     client = new YuqueClient(mockToken);
   });
 
+  describe('constructor', () => {
+    it('should use default base URL when not provided', () => {
+      const c = new YuqueClient(mockToken);
+      expect(mockedAxios.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          baseURL: 'https://www.yuque.com/api/v2',
+        })
+      );
+    });
+
+    it('should use custom base URL when provided', () => {
+      const customURL = 'https://yuque.internal.com/api/v2';
+      const c = new YuqueClient(mockToken, customURL);
+      expect(mockedAxios.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          baseURL: customURL,
+        })
+      );
+    });
+  });
+
   describe('getUser', () => {
     it('should fetch user data', async () => {
       const mockUser = {

--- a/tests/services/yuque-client.test.ts
+++ b/tests/services/yuque-client.test.ts
@@ -22,7 +22,7 @@ describe('YuqueClient', () => {
 
   describe('constructor', () => {
     it('should use default base URL when not provided', () => {
-      const c = new YuqueClient(mockToken);
+      new YuqueClient(mockToken);
       expect(mockedAxios.create).toHaveBeenCalledWith(
         expect.objectContaining({
           baseURL: 'https://www.yuque.com/api/v2',
@@ -32,7 +32,7 @@ describe('YuqueClient', () => {
 
     it('should use custom base URL when provided', () => {
       const customURL = 'https://yuque.internal.com/api/v2';
-      const c = new YuqueClient(mockToken, customURL);
+      new YuqueClient(mockToken, customURL);
       expect(mockedAxios.create).toHaveBeenCalledWith(
         expect.objectContaining({
           baseURL: customURL,


### PR DESCRIPTION
Allow users to configure a custom API base URL via YUQUE_BASE_URL env var or --base-url CLI arg, enabling connections to privately deployed Yuque instances. Also propagates the option through the install/setup commands.

### What does this PR do?

<!-- Brief description of the changes -->
支持自定义语雀 API 基础地址，允许连接私有化部署的语雀实例。

  - 新增 YUQUE_BASE_URL 环境变量和 --base-url= CLI 参数
  - install 和 setup 子命令也支持 --base-url=，会自动写入客户端配置
  - 不设置时默认仍为 https://www.yuque.com/api/v2，完全向后兼容

### Related Issues

<!-- fixes #123, closes #456 -->

### Type of Change

- [ ] 🐞 Bug fix
- [x] ✨ New feature
- [ ] 📝 Documentation update
- [ ] ♻️ Refactoring
- [ ] ⚡️ Performance improvement

### Checklist

- [x] Tests added / updated
- [x] Documentation updated (if applicable)
- [x] Changelog entry added (if user-facing)
- [x] No breaking changes (or documented in description)

### Changelog Entry

<!-- What should appear in CHANGELOG.md? Leave empty if not user-facing. -->
  Added: 支持通过 YUQUE_BASE_URL 环境变量或 --base-url CLI 参数自定义 API 基础地址，适配私有化部署场景。



