### PR TITLE
feat: add YMD doc read/write and board resource tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### ✨ Features
+
+- Add board resource tools for reading, creating, and updating YFM board cards.
+
 ### 🐞 Bug Fixes
 
 - Fix Node.js v24 compatibility by replacing ESM JSON import with createRequire (#52) (#52)

--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ The server supports multiple ways to provide your Yuque API token:
 
 ---
 
-## Available Tools (16)
+## Available Tools (19)
 
 | Category | Tools |
 |----------|-------|
@@ -211,6 +211,7 @@ The server supports multiple ways to provide your Yuque API token:
 | **Search** | `yuque_search` |
 | **Books** | `yuque_list_books`, `yuque_get_book`, `yuque_create_book`, `yuque_update_book` |
 | **Docs** | `yuque_list_docs`, `yuque_get_doc`, `yuque_create_doc`, `yuque_update_doc` |
+| **Resources** | `yuque_get_resource`, `yuque_create_resource`, `yuque_update_resource` |
 | **TOC** | `yuque_get_toc`, `yuque_update_toc` |
 | **Notes** | `yuque_list_notes`, `yuque_get_note`, `yuque_create_note`, `yuque_update_note` |
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -203,7 +203,7 @@ claude mcp add yuque-mcp -- npx -y yuque-mcp
 
 ---
 
-## 可用工具（16 个）
+## 可用工具（19 个）
 
 | 分类 | 工具 |
 |------|------|
@@ -211,6 +211,7 @@ claude mcp add yuque-mcp -- npx -y yuque-mcp
 | **搜索** | `yuque_search` |
 | **知识库** | `yuque_list_books`、`yuque_get_book`、`yuque_create_book`、`yuque_update_book` |
 | **文档** | `yuque_list_docs`、`yuque_get_doc`、`yuque_create_doc`、`yuque_update_doc` |
+| **资源** | `yuque_get_resource`、`yuque_create_resource`、`yuque_update_resource` |
 | **目录** | `yuque_get_toc`、`yuque_update_toc` |
 | **小记** | `yuque_list_notes`、`yuque_get_note`、`yuque_create_note`、`yuque_update_note` |
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -13,6 +13,7 @@ import { docTools } from './tools/doc.js';
 import { tocTools } from './tools/toc.js';
 import { searchTools } from './tools/search.js';
 import { noteTools } from './tools/note.js';
+import { resourceTools } from './tools/resource.js';
 
 const require = createRequire(import.meta.url);
 const packageJson = require('../package.json');
@@ -41,6 +42,7 @@ export function createServer(token: string) {
     ...tocTools,
     ...searchTools,
     ...noteTools,
+    ...resourceTools,
   };
 
   // Register list_tools handler

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -76,6 +76,21 @@ export interface YuqueDoc {
   description: string;
 }
 
+export interface YuqueYmdDoc {
+  doc_id: number;
+  title: string;
+  url: string;
+  yfm: string;
+  updated_at: string;
+}
+
+export interface YuqueYmdDocWriteResult {
+  doc_id: number;
+  title: string;
+  url: string;
+  updated_at: string;
+}
+
 export interface YuqueTocItem {
   title: string;
   uuid: string;
@@ -179,6 +194,7 @@ export interface UpdateDocData {
   title?: string;
   slug?: string;
   body?: string;
+  format?: string;
   public?: number;
 }
 // 添加到 src/services/types.ts 的小记类型定义
@@ -190,7 +206,7 @@ export interface YuqueNoteContent {
   source?: string;
   html?: string;
   draft_version?: number;
-  doc_dynamic_data?: any[];
+  doc_dynamic_data?: unknown[];
 }
 
 export interface YuqueNote {

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -91,6 +91,60 @@ export interface YuqueYmdDocWriteResult {
   updated_at: string;
 }
 
+export type YuqueResourceType = 'board';
+export type YuqueBoardType = 'mindmap' | 'flowchart' | 'architecturediagram';
+export type YuqueBoardJsonScalar = string | number | boolean | null;
+export type YuqueBoardJsonValue =
+  | YuqueBoardJsonScalar
+  | YuqueBoardJsonValue[]
+  | { [key: string]: YuqueBoardJsonValue };
+export type YuqueBoardDsl = Record<string, YuqueBoardJsonValue>;
+
+export interface YuqueResourceLocatorData {
+  resource_type: YuqueResourceType;
+  doc_id?: number;
+  url?: string;
+}
+
+export interface YuqueResourceGetData extends YuqueResourceLocatorData {
+  resource_id: string;
+}
+
+export interface YuqueResourceCreateData extends YuqueResourceLocatorData {
+  type: YuqueBoardType;
+  dsl: string;
+  insert_after_lake_id?: string;
+}
+
+export interface YuqueResourceUpdateData extends YuqueResourceGetData {
+  text?: string;
+  dsl?: YuqueBoardDsl;
+}
+
+export interface YuqueResourceResult {
+  doc_id: number;
+  title: string;
+  url: string;
+  updated_at: string;
+  board: {
+    page_ref: {
+      src: string;
+    };
+    resource: {
+      id: string | null;
+      kind: string;
+    };
+    dsl: YuqueBoardDsl;
+    summary: {
+      cell_count: number;
+      type_counts: Record<string, number>;
+      shape_counts: Record<string, number>;
+      has_viewport: boolean;
+      has_search: boolean;
+    };
+  };
+}
+
 export interface YuqueTocItem {
   title: string;
   uuid: string;

--- a/src/services/yuque-client.ts
+++ b/src/services/yuque-client.ts
@@ -4,6 +4,8 @@ import type {
   YuqueGroup,
   YuqueRepo,
   YuqueDoc,
+  YuqueYmdDoc,
+  YuqueYmdDocWriteResult,
   YuqueTocItem,
   YuqueSearchResult,
   YuqueDocVersion,
@@ -153,6 +155,16 @@ export class YuqueClient {
     });
   }
 
+  /** Get a document body through the YMD/YFM-compatible reader. */
+  async getYmdDoc(docId: number): Promise<YuqueYmdDoc> {
+    return withErrorHandling(async () => {
+      const r = await this.client.get<YuqueApiResponse<YuqueYmdDoc>>('/yfm/docs', {
+        params: { doc_id: docId },
+      });
+      return r.data.data;
+    });
+  }
+
   /** Create a new document in a repo. */
   async createDoc(repoId: string | number, data: CreateDocData): Promise<YuqueDoc> {
     return withErrorHandling(async () => {
@@ -165,6 +177,17 @@ export class YuqueClient {
   async updateDoc(repoId: string | number, docId: string | number, data: UpdateDocData): Promise<YuqueDoc> {
     return withErrorHandling(async () => {
       const r = await this.client.put<YuqueApiResponse<YuqueDoc>>(`/repos/${repoId}/docs/${docId}`, data);
+      return r.data.data;
+    });
+  }
+
+  /** Update a document body through the YMD/YFM-compatible writer. */
+  async updateYmdDoc(docId: number, ymd: string): Promise<YuqueYmdDocWriteResult> {
+    return withErrorHandling(async () => {
+      const r = await this.client.put<YuqueApiResponse<YuqueYmdDocWriteResult>>('/yfm/docs', {
+        doc_id: docId,
+        yfm: ymd,
+      });
       return r.data.data;
     });
   }

--- a/src/services/yuque-client.ts
+++ b/src/services/yuque-client.ts
@@ -21,6 +21,10 @@ import type {
   CreateNoteData,
   CreateNoteResponse,
   UpdateNoteData,
+  YuqueResourceCreateData,
+  YuqueResourceGetData,
+  YuqueResourceResult,
+  YuqueResourceUpdateData,
 } from './types.js';
 import { handleYuqueError } from '../utils/error.js';
 
@@ -34,6 +38,25 @@ async function withErrorHandling<T>(fn: () => Promise<T>): Promise<T> {
   } catch (error) {
     handleYuqueError(error);
   }
+}
+
+function toResourcePayload<T extends { resource_type: string }>(data: T): Record<string, unknown> {
+  const { resource_type: resourceType, ...payload } = data;
+  void resourceType;
+  return Object.fromEntries(
+    Object.entries(payload as Record<string, unknown>).filter(([, value]) => value !== undefined)
+  );
+}
+
+function toBoardResourcePayload<T extends { resource_type: string; resource_id?: string }>(
+  data: T
+): Record<string, unknown> {
+  const { resource_id: resourceId, ...payload } = toResourcePayload(data);
+  // The public v2 board API names this field src, but expects the raw resource id.
+  return {
+    ...payload,
+    ...(resourceId !== undefined && { src: resourceId }),
+  };
 }
 
 export class YuqueClient {
@@ -188,6 +211,38 @@ export class YuqueClient {
         doc_id: docId,
         yfm: ymd,
       });
+      return r.data.data;
+    });
+  }
+
+  /** Get a structured resource view from a document. */
+  async getResource(data: YuqueResourceGetData): Promise<YuqueResourceResult> {
+    return withErrorHandling(async () => {
+      const r = await this.client.get<YuqueApiResponse<YuqueResourceResult>>('/yfm/boards', {
+        params: toBoardResourcePayload(data),
+      });
+      return r.data.data;
+    });
+  }
+
+  /** Create a structured resource in a document. */
+  async createResource(data: YuqueResourceCreateData): Promise<YuqueResourceResult> {
+    return withErrorHandling(async () => {
+      const r = await this.client.post<YuqueApiResponse<YuqueResourceResult>>(
+        '/yfm/boards',
+        toResourcePayload(data)
+      );
+      return r.data.data;
+    });
+  }
+
+  /** Update a structured resource in a document. */
+  async updateResource(data: YuqueResourceUpdateData): Promise<YuqueResourceResult> {
+    return withErrorHandling(async () => {
+      const r = await this.client.put<YuqueApiResponse<YuqueResourceResult>>(
+        '/yfm/boards',
+        toBoardResourcePayload(data)
+      );
       return r.data.data;
     });
   }

--- a/src/tools/doc.ts
+++ b/src/tools/doc.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import type { YuqueClient } from '../services/yuque-client.js';
+import type { YuqueDoc, YuqueYmdDoc } from '../services/types.js';
 import { formatDocSummary, formatDoc } from '../utils/format.js';
 
 async function appendDocToToc(
@@ -20,6 +21,20 @@ async function appendDocToToc(
   } catch {
     return 'Document created successfully but failed to auto-append to TOC. Please manually arrange it in the TOC via the Yuque web interface.';
   }
+}
+
+function shouldUseYmd(format?: string): boolean {
+  return !format || format === 'markdown';
+}
+
+function withYmdBody(doc: YuqueDoc, ymdDoc: YuqueYmdDoc): YuqueDoc {
+  return {
+    ...doc,
+    title: ymdDoc.title || doc.title,
+    body: ymdDoc.yfm,
+    format: 'markdown',
+    updated_at: ymdDoc.updated_at || doc.updated_at,
+  };
 }
 
 export const docTools = {
@@ -52,6 +67,12 @@ export const docTools = {
       doc_id: z
         .union([z.string(), z.number()])
         .describe('Document ID or slug'),
+      format: z
+        .enum(['markdown', 'lake', 'html'])
+        .optional()
+        .describe(
+          'Content format to read. Omit or use markdown to read through the YMD-compatible flow; use lake/html for the legacy document API.'
+        ),
       include_lake: z
         .boolean()
         .optional()
@@ -65,16 +86,20 @@ export const docTools = {
       args: {
         repo_id: string | number;
         doc_id: string | number;
+        format?: 'markdown' | 'lake' | 'html';
         include_lake: boolean;
       }
     ) => {
       const doc = await client.getDoc(args.repo_id, args.doc_id);
+      const formattedDoc = shouldUseYmd(args.format)
+        ? withYmdBody(doc, await client.getYmdDoc(doc.id))
+        : doc;
       return {
         content: [
           {
             type: 'text' as const,
             text: JSON.stringify(
-              formatDoc(doc, { includeLake: args.include_lake }),
+              formatDoc(formattedDoc, { includeLake: args.include_lake }),
               null,
               2
             ),
@@ -141,6 +166,12 @@ export const docTools = {
       title: z.string().optional().describe('New document title'),
       slug: z.string().optional().describe('New document slug'),
       body: z.string().optional().describe('New document content'),
+      format: z
+        .enum(['markdown', 'lake', 'html'])
+        .optional()
+        .describe(
+          'Content format for body. Omit or use markdown to write through the YMD-compatible flow; use lake/html for the legacy document API.'
+        ),
       public: z.number().optional().describe('Public visibility: 0 (private) or 1 (public)'),
     }),
     handler: async (
@@ -151,14 +182,38 @@ export const docTools = {
         title?: string;
         slug?: string;
         body?: string;
+        format?: 'markdown' | 'lake' | 'html';
         public?: number;
       }
     ) => {
-      const data = {
+      const metadata = {
         title: args.title,
         slug: args.slug,
-        body: args.body,
         public: args.public,
+      };
+      const hasMetadataUpdate = Object.values(metadata).some((value) => value !== undefined);
+
+      if (args.body !== undefined && shouldUseYmd(args.format)) {
+        const currentDoc = await client.getDoc(args.repo_id, args.doc_id);
+        const doc = hasMetadataUpdate
+          ? await client.updateDoc(args.repo_id, args.doc_id, metadata)
+          : currentDoc;
+        await client.updateYmdDoc(currentDoc.id, args.body);
+        const ymdDoc = await client.getYmdDoc(currentDoc.id);
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify(formatDoc(withYmdBody(doc, ymdDoc)), null, 2),
+            },
+          ],
+        };
+      }
+
+      const data = {
+        ...metadata,
+        body: args.body,
+        format: args.format,
       };
       const doc = await client.updateDoc(args.repo_id, args.doc_id, data);
       return {

--- a/src/tools/resource.ts
+++ b/src/tools/resource.ts
@@ -1,0 +1,182 @@
+import { z } from 'zod';
+import type { YuqueClient } from '../services/yuque-client.js';
+import type { YuqueBoardDsl, YuqueBoardType, YuqueResourceType } from '../services/types.js';
+
+const resourceTypeSchema = z
+  .enum(['board'])
+  .describe('Resource type. Currently only board is supported.');
+
+const docLocatorFields = {
+  doc_id: z
+    .number()
+    .int()
+    .positive()
+    .optional()
+    .describe('Yuque document ID. Provide either doc_id or url, but not both.'),
+  url: z
+    .string()
+    .trim()
+    .min(1)
+    .max(2048)
+    .optional()
+    .describe('Yuque document URL. Provide either url or doc_id, but not both.'),
+};
+
+const boardResourceIdSchema = z
+  .string()
+  .min(1)
+  .refine((value) => !value.includes('://'), {
+    message: 'resource_id must be a raw board resource id',
+  })
+  .describe(
+    'Raw board resource ID from board://<resource_id>; do not pass the full board:// locator.'
+  );
+
+const boardDslSchema = (z.record(z.unknown()) as z.ZodType<YuqueBoardDsl>).describe(
+  'Board JSON DSL object. It is passed through to Yuque public v2 as-is.'
+);
+
+function validateDocLocator(value: { doc_id?: number; url?: string }, ctx: z.RefinementCtx) {
+  const hasDocId = value.doc_id !== undefined;
+  const hasUrl = value.url !== undefined;
+  if (hasDocId === hasUrl) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['doc_id'],
+      message: 'Provide exactly one of doc_id or url',
+    });
+  }
+}
+
+function validateBoardUpdateBody(
+  value: { text?: string; dsl?: YuqueBoardDsl },
+  ctx: z.RefinementCtx
+) {
+  const hasText = value.text !== undefined;
+  const hasDsl = value.dsl !== undefined;
+  if (hasText === hasDsl) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['text'],
+      message: 'Provide exactly one of text or dsl',
+    });
+  }
+}
+
+const getResourceSchema = z
+  .object({
+    resource_type: resourceTypeSchema,
+    ...docLocatorFields,
+    resource_id: boardResourceIdSchema,
+  })
+  .superRefine(validateDocLocator);
+
+const createResourceSchema = z
+  .object({
+    resource_type: resourceTypeSchema,
+    ...docLocatorFields,
+    type: z
+      .enum(['mindmap', 'flowchart', 'architecturediagram'])
+      .describe('Board type: mindmap, flowchart, or architecturediagram.'),
+    dsl: z.string().min(1).describe('Board text DSL content.'),
+    insert_after_lake_id: z
+      .string()
+      .min(1)
+      .optional()
+      .describe('Insert after a top-level Lake node. Omit to append to the document end.'),
+  })
+  .superRefine(validateDocLocator);
+
+const updateResourceSchema = z
+  .object({
+    resource_type: resourceTypeSchema,
+    ...docLocatorFields,
+    resource_id: boardResourceIdSchema,
+    text: z.string().optional().describe('New board text DSL. Mutually exclusive with dsl.'),
+    dsl: boardDslSchema.optional(),
+  })
+  .superRefine((value, ctx) => {
+    validateDocLocator(value, ctx);
+    validateBoardUpdateBody(value, ctx);
+  });
+
+export const resourceTools = {
+  yuque_get_resource: {
+    description:
+      'Read a structured resource view from a Yuque document. Currently resource_type only supports board; pass the raw resource_id, not board://<resource_id>.',
+    inputSchema: getResourceSchema,
+    handler: async (
+      client: YuqueClient,
+      args: {
+        resource_type: YuqueResourceType;
+        doc_id?: number;
+        url?: string;
+        resource_id: string;
+      }
+    ) => {
+      const result = await client.getResource(args);
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: JSON.stringify(result, null, 2),
+          },
+        ],
+      };
+    },
+  },
+
+  yuque_create_resource: {
+    description:
+      'Create a structured resource in a Yuque document. Currently resource_type only supports board: mindmap, flowchart, or architecturediagram.',
+    inputSchema: createResourceSchema,
+    handler: async (
+      client: YuqueClient,
+      args: {
+        resource_type: YuqueResourceType;
+        doc_id?: number;
+        url?: string;
+        type: YuqueBoardType;
+        dsl: string;
+        insert_after_lake_id?: string;
+      }
+    ) => {
+      const result = await client.createResource(args);
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: JSON.stringify(result, null, 2),
+          },
+        ],
+      };
+    },
+  },
+
+  yuque_update_resource: {
+    description:
+      'Update a structured resource in a Yuque document. Currently resource_type only supports board; provide exactly one of text or dsl.',
+    inputSchema: updateResourceSchema,
+    handler: async (
+      client: YuqueClient,
+      args: {
+        resource_type: YuqueResourceType;
+        doc_id?: number;
+        url?: string;
+        resource_id: string;
+        text?: string;
+        dsl?: YuqueBoardDsl;
+      }
+    ) => {
+      const result = await client.updateResource(args);
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: JSON.stringify(result, null, 2),
+          },
+        ],
+      };
+    },
+  },
+};

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -15,11 +15,26 @@ describe('createServer', () => {
     expect(MCP_SERVER_VERSION).toBe(packageJson.version);
   });
 
-  it('should register all 16 tools', async () => {
+  it('should register all 19 tools', async () => {
     const server = createServer('test-token');
+    const listToolsHandler = (
+      server as unknown as {
+        _requestHandlers: Map<
+          string,
+          (request: unknown, extra: unknown) => Promise<{ tools: Array<{ name: string }> }>
+        >;
+      }
+    )._requestHandlers.get('tools/list');
 
-    // Access the internal server to list tools
-    // The server should have handlers registered
-    expect(server).toBeDefined();
+    const result = await listToolsHandler?.({ method: 'tools/list', params: {} }, {});
+
+    expect(result?.tools).toHaveLength(19);
+    expect(result?.tools.map((tool) => tool.name)).toEqual(
+      expect.arrayContaining([
+        'yuque_get_resource',
+        'yuque_create_resource',
+        'yuque_update_resource',
+      ])
+    );
   });
 });

--- a/tests/services/yuque-client.test.ts
+++ b/tests/services/yuque-client.test.ts
@@ -187,6 +187,25 @@ describe('YuqueClient', () => {
       expect(mockClient.get).toHaveBeenCalledWith('/repos/1/docs/1');
     });
 
+    it('should get YMD doc content', async () => {
+      const mockYmdDoc = {
+        doc_id: 1,
+        title: 'Test Doc',
+        url: '/user/repo/test-doc',
+        yfm: '# Test Doc',
+        updated_at: '2024-01-02',
+      };
+
+      const mockClient = client['client'] as { get: ReturnType<typeof vi.fn> };
+      mockClient.get.mockResolvedValue({ data: { data: mockYmdDoc } });
+
+      const result = await client.getYmdDoc(1);
+      expect(result).toEqual(mockYmdDoc);
+      expect(mockClient.get).toHaveBeenCalledWith('/yfm/docs', {
+        params: { doc_id: 1 },
+      });
+    });
+
     it('should create doc', async () => {
       const mockDoc = { id: 1, title: 'New Doc', body: 'Content' };
       const mockClient = client['client'] as { post: ReturnType<typeof vi.fn> };
@@ -212,6 +231,25 @@ describe('YuqueClient', () => {
       expect(result).toEqual(mockDoc);
       expect(mockClient.put).toHaveBeenCalledWith('/repos/1/docs/1', {
         title: 'Updated Doc',
+      });
+    });
+
+    it('should update YMD doc content', async () => {
+      const mockResult = {
+        doc_id: 1,
+        title: 'Updated Doc',
+        url: '/user/repo/test-doc',
+        updated_at: '2024-01-03',
+      };
+
+      const mockClient = client['client'] as { put: ReturnType<typeof vi.fn> };
+      mockClient.put.mockResolvedValue({ data: { data: mockResult } });
+
+      const result = await client.updateYmdDoc(1, '# Updated Doc');
+      expect(result).toEqual(mockResult);
+      expect(mockClient.put).toHaveBeenCalledWith('/yfm/docs', {
+        doc_id: 1,
+        yfm: '# Updated Doc',
       });
     });
 

--- a/tests/services/yuque-client.test.ts
+++ b/tests/services/yuque-client.test.ts
@@ -253,6 +253,123 @@ describe('YuqueClient', () => {
       });
     });
 
+    it('should get resource detail without forwarding resource_type', async () => {
+      const mockResult = {
+        doc_id: 1,
+        title: 'Test Doc',
+        url: '/user/repo/test-doc',
+        updated_at: '2024-01-03',
+        board: {
+          page_ref: { src: 'board://board-1' },
+          resource: { id: 'board-1', kind: 'mindmap' },
+          dsl: { text: '- root', format: 'text', language: 'mindmap' },
+          summary: {
+            cell_count: 1,
+            type_counts: {},
+            shape_counts: {},
+            has_viewport: false,
+            has_search: false,
+          },
+        },
+      };
+
+      const mockClient = client['client'] as { get: ReturnType<typeof vi.fn> };
+      mockClient.get.mockResolvedValue({ data: { data: mockResult } });
+
+      const result = await client.getResource({
+        resource_type: 'board',
+        doc_id: 1,
+        resource_id: 'board-1',
+      });
+      expect(result).toEqual(mockResult);
+      expect(mockClient.get).toHaveBeenCalledWith('/yfm/boards', {
+        params: { doc_id: 1, src: 'board-1' },
+      });
+    });
+
+    it('should create resource without forwarding resource_type or undefined fields', async () => {
+      const mockResult = {
+        doc_id: 1,
+        title: 'Test Doc',
+        url: '/user/repo/test-doc',
+        updated_at: '2024-01-03',
+        board: {
+          page_ref: { src: 'board://board-1' },
+          resource: { id: 'board-1', kind: 'mindmap' },
+          dsl: { text: '- root', format: 'text', language: 'mindmap' },
+          summary: {
+            cell_count: 1,
+            type_counts: {},
+            shape_counts: {},
+            has_viewport: false,
+            has_search: false,
+          },
+        },
+      };
+
+      const mockClient = client['client'] as { post: ReturnType<typeof vi.fn> };
+      mockClient.post.mockResolvedValue({ data: { data: mockResult } });
+
+      const result = await client.createResource({
+        resource_type: 'board',
+        doc_id: 1,
+        type: 'mindmap',
+        dsl: '- root',
+      });
+      expect(result).toEqual(mockResult);
+      expect(mockClient.post).toHaveBeenCalledWith('/yfm/boards', {
+        doc_id: 1,
+        type: 'mindmap',
+        dsl: '- root',
+      });
+    });
+
+    it('should update resource with JSON DSL body', async () => {
+      const nextDsl = {
+        value: {
+          diagramData: {
+            body: [],
+          },
+        },
+        format: 'json',
+        language: 'json',
+      };
+      const mockResult = {
+        doc_id: 1,
+        title: 'Test Doc',
+        url: '/user/repo/test-doc',
+        updated_at: '2024-01-03',
+        board: {
+          page_ref: { src: 'board://board-1' },
+          resource: { id: 'board-1', kind: 'flowchart' },
+          dsl: nextDsl,
+          summary: {
+            cell_count: 0,
+            type_counts: {},
+            shape_counts: {},
+            has_viewport: false,
+            has_search: false,
+          },
+        },
+      };
+
+      const mockClient = client['client'] as { put: ReturnType<typeof vi.fn> };
+      mockClient.put.mockResolvedValue({ data: { data: mockResult } });
+
+      const result = await client.updateResource({
+        resource_type: 'board',
+        url: 'https://www.yuque.com/user/repo/doc',
+        resource_id: 'board-1',
+        dsl: nextDsl,
+      });
+      expect(result).toEqual(mockResult);
+      expect(mockClient.put).toHaveBeenCalledWith('/yfm/boards', {
+        url: 'https://www.yuque.com/user/repo/doc',
+        src: 'board-1',
+        dsl: nextDsl,
+      });
+    });
+
     it('should delete doc', async () => {
       const mockClient = client['client'] as { delete: ReturnType<typeof vi.fn> };
       mockClient.delete.mockResolvedValue({});

--- a/tests/tools/doc.test.ts
+++ b/tests/tools/doc.test.ts
@@ -5,8 +5,10 @@ import type { YuqueClient } from '../../src/services/yuque-client.js';
 const mockClient = {
   listDocs: vi.fn(),
   getDoc: vi.fn(),
+  getYmdDoc: vi.fn(),
   createDoc: vi.fn(),
   updateDoc: vi.fn(),
+  updateYmdDoc: vi.fn(),
   deleteDoc: vi.fn(),
   updateToc: vi.fn(),
 } as unknown as YuqueClient;
@@ -34,16 +36,22 @@ describe('docTools', () => {
   });
 
   describe('yuque_get_doc', () => {
-    it('should get doc with content', async () => {
+    it('should get doc with YMD-compatible content by default', async () => {
       (mockClient.getDoc as ReturnType<typeof vi.fn>).mockResolvedValue({
         id: 1, slug: 'doc1', title: 'Doc 1', body: '# Hello', body_html: '<h1>Hello</h1>',
         format: 'markdown', created_at: '2024-01-01', updated_at: '2024-01-02', word_count: 100,
       });
+      (mockClient.getYmdDoc as ReturnType<typeof vi.fn>).mockResolvedValue({
+        doc_id: 1, title: 'Doc 1', url: '/user/repo/doc1', yfm: '# Hello from YMD', updated_at: '2024-01-03',
+      });
       const result = await docTools.yuque_get_doc.handler(mockClient, { repo_id: 1, doc_id: 1, include_lake: false } as never);
       const parsed = JSON.parse(result.content[0].text);
-      expect(parsed).toHaveProperty('body', '# Hello');
+      expect(parsed).toHaveProperty('body', '# Hello from YMD');
+      expect(parsed).toHaveProperty('format', 'markdown');
+      expect(parsed).toHaveProperty('updated_at', '2024-01-03');
       expect(parsed).not.toHaveProperty('body_lake');
       expect(mockClient.getDoc).toHaveBeenCalledWith(1, 1);
+      expect(mockClient.getYmdDoc).toHaveBeenCalledWith(1);
     });
 
     it('should include body_lake when include_lake is true', async () => {
@@ -52,9 +60,29 @@ describe('docTools', () => {
         body_lake: '<!doctype lake><p>Hello</p>',
         format: 'markdown', created_at: '2024-01-01', updated_at: '2024-01-02', word_count: 100,
       });
+      (mockClient.getYmdDoc as ReturnType<typeof vi.fn>).mockResolvedValue({
+        doc_id: 1, title: 'Doc 1', url: '/user/repo/doc1', yfm: '# Hello from YMD', updated_at: '2024-01-03',
+      });
       const result = await docTools.yuque_get_doc.handler(mockClient, { repo_id: 1, doc_id: 1, include_lake: true } as never);
       const parsed = JSON.parse(result.content[0].text);
+      expect(parsed).toHaveProperty('body', '# Hello from YMD');
       expect(parsed).toHaveProperty('body_lake', '<!doctype lake><p>Hello</p>');
+    });
+
+    it('should use legacy doc content when read format is lake', async () => {
+      (mockClient.getDoc as ReturnType<typeof vi.fn>).mockResolvedValue({
+        id: 1, slug: 'doc1', title: 'Doc 1', body: '# Hello', body_html: '<h1>Hello</h1>',
+        format: 'lake', created_at: '2024-01-01', updated_at: '2024-01-02', word_count: 100,
+      });
+
+      const result = await docTools.yuque_get_doc.handler(mockClient, {
+        repo_id: 1, doc_id: 1, format: 'lake', include_lake: false,
+      } as never);
+
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed).toHaveProperty('body', '# Hello');
+      expect(parsed).toHaveProperty('format', 'lake');
+      expect(mockClient.getYmdDoc).not.toHaveBeenCalled();
     });
   });
 
@@ -100,7 +128,7 @@ describe('docTools', () => {
   });
 
   describe('yuque_update_doc', () => {
-    it('should update doc', async () => {
+    it('should update doc metadata without YMD body update', async () => {
       (mockClient.updateDoc as ReturnType<typeof vi.fn>).mockResolvedValue({
         id: 1, slug: 'doc1', title: 'Updated', body: 'New content',
         format: 'markdown', created_at: '2024-01-01', updated_at: '2024-01-02', word_count: 2,
@@ -110,6 +138,83 @@ describe('docTools', () => {
       } as never);
       const parsed = JSON.parse(result.content[0].text);
       expect(parsed).toHaveProperty('title', 'Updated');
+      expect(mockClient.updateDoc).toHaveBeenCalledWith(1, 1, expect.objectContaining({ title: 'Updated' }));
+      expect(mockClient.updateYmdDoc).not.toHaveBeenCalled();
+    });
+
+    it.each([undefined, 'markdown'] as const)(
+      'should update markdown body through YMD flow when format is %s',
+      async (format) => {
+        (mockClient.getDoc as ReturnType<typeof vi.fn>).mockResolvedValue({
+          id: 1, slug: 'doc1', title: 'Doc 1', body: 'Old content',
+          format: 'markdown', created_at: '2024-01-01', updated_at: '2024-01-02', word_count: 2,
+        });
+        (mockClient.updateYmdDoc as ReturnType<typeof vi.fn>).mockResolvedValue({
+          doc_id: 1, title: 'Doc 1', url: '/user/repo/doc1', updated_at: '2024-01-03',
+        });
+        (mockClient.getYmdDoc as ReturnType<typeof vi.fn>).mockResolvedValue({
+          doc_id: 1, title: 'Doc 1', url: '/user/repo/doc1', yfm: '# Updated YMD', updated_at: '2024-01-03',
+        });
+
+        const result = await docTools.yuque_update_doc.handler(mockClient, {
+          repo_id: 1, doc_id: 1, body: '# Updated YMD', format,
+        } as never);
+
+        const parsed = JSON.parse(result.content[0].text);
+        expect(parsed).toHaveProperty('body', '# Updated YMD');
+        expect(parsed).toHaveProperty('format', 'markdown');
+        expect(mockClient.getDoc).toHaveBeenCalledWith(1, 1);
+        expect(mockClient.updateYmdDoc).toHaveBeenCalledWith(1, '# Updated YMD');
+        expect(mockClient.getYmdDoc).toHaveBeenCalledWith(1);
+        expect(mockClient.updateDoc).not.toHaveBeenCalled();
+      }
+    );
+
+    it('should update metadata and markdown body through mixed legacy/YMD flow', async () => {
+      (mockClient.getDoc as ReturnType<typeof vi.fn>).mockResolvedValue({
+        id: 1, slug: 'doc1', title: 'Doc 1', body: 'Old content',
+        format: 'markdown', created_at: '2024-01-01', updated_at: '2024-01-02', word_count: 2,
+      });
+      (mockClient.updateDoc as ReturnType<typeof vi.fn>).mockResolvedValue({
+        id: 1, slug: 'doc1', title: 'Updated', body: 'Old content',
+        format: 'markdown', created_at: '2024-01-01', updated_at: '2024-01-03', word_count: 2,
+      });
+      (mockClient.updateYmdDoc as ReturnType<typeof vi.fn>).mockResolvedValue({
+        doc_id: 1, title: 'Updated', url: '/user/repo/doc1', updated_at: '2024-01-04',
+      });
+      (mockClient.getYmdDoc as ReturnType<typeof vi.fn>).mockResolvedValue({
+        doc_id: 1, title: 'Updated', url: '/user/repo/doc1', yfm: '# Updated YMD', updated_at: '2024-01-04',
+      });
+
+      const result = await docTools.yuque_update_doc.handler(mockClient, {
+        repo_id: 1, doc_id: 1, title: 'Updated', body: '# Updated YMD',
+      } as never);
+
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed).toHaveProperty('title', 'Updated');
+      expect(parsed).toHaveProperty('body', '# Updated YMD');
+      expect(mockClient.updateDoc).toHaveBeenCalledWith(1, 1, expect.objectContaining({ title: 'Updated' }));
+      expect(mockClient.updateYmdDoc).toHaveBeenCalledWith(1, '# Updated YMD');
+    });
+
+    it('should use legacy doc update when body format is lake', async () => {
+      (mockClient.updateDoc as ReturnType<typeof vi.fn>).mockResolvedValue({
+        id: 1, slug: 'doc1', title: 'Updated', body: '<!doctype lake><p>Updated</p>',
+        format: 'lake', created_at: '2024-01-01', updated_at: '2024-01-02', word_count: 2,
+      });
+
+      const result = await docTools.yuque_update_doc.handler(mockClient, {
+        repo_id: 1, doc_id: 1, body: '<!doctype lake><p>Updated</p>', format: 'lake',
+      } as never);
+
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed).toHaveProperty('format', 'lake');
+      expect(mockClient.updateDoc).toHaveBeenCalledWith(1, 1, expect.objectContaining({
+        body: '<!doctype lake><p>Updated</p>',
+        format: 'lake',
+      }));
+      expect(mockClient.updateYmdDoc).not.toHaveBeenCalled();
+      expect(mockClient.getYmdDoc).not.toHaveBeenCalled();
     });
   });
 });

--- a/tests/tools/resource.test.ts
+++ b/tests/tools/resource.test.ts
@@ -1,0 +1,201 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { resourceTools } from '../../src/tools/resource.js';
+import type { YuqueClient } from '../../src/services/yuque-client.js';
+
+const mockClient = {
+  getResource: vi.fn(),
+  createResource: vi.fn(),
+  updateResource: vi.fn(),
+} as unknown as YuqueClient;
+
+const mockBoardResult = {
+  doc_id: 1,
+  title: 'Doc 1',
+  url: '/user/repo/doc1',
+  updated_at: '2024-01-03',
+  board: {
+    page_ref: { src: 'board://board-1' },
+    resource: { id: 'board-1', kind: 'mindmap' },
+    dsl: { text: '- root', format: 'text', language: 'mindmap' },
+    summary: {
+      cell_count: 1,
+      type_counts: {},
+      shape_counts: {},
+      has_viewport: false,
+      has_search: false,
+    },
+  },
+};
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('resourceTools', () => {
+  describe('yuque_get_resource', () => {
+    it('should get board resource detail', async () => {
+      (mockClient.getResource as ReturnType<typeof vi.fn>).mockResolvedValue(mockBoardResult);
+
+      const result = await resourceTools.yuque_get_resource.handler(mockClient, {
+        resource_type: 'board',
+        doc_id: 1,
+        resource_id: 'board-1',
+      } as never);
+
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed.board.page_ref.src).toBe('board://board-1');
+      expect(mockClient.getResource).toHaveBeenCalledWith({
+        resource_type: 'board',
+        doc_id: 1,
+        resource_id: 'board-1',
+      });
+    });
+
+    it('should reject when doc_id and url are both provided', () => {
+      const result = resourceTools.yuque_get_resource.inputSchema.safeParse({
+        resource_type: 'board',
+        doc_id: 1,
+        url: 'https://www.yuque.com/user/repo/doc',
+        resource_id: 'board-1',
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error?.issues.some((issue) => issue.message.includes('doc_id or url'))).toBe(
+        true
+      );
+    });
+
+    it('should reject board locator resource_id', () => {
+      const result = resourceTools.yuque_get_resource.inputSchema.safeParse({
+        resource_type: 'board',
+        doc_id: 1,
+        resource_id: 'board://board-1',
+      });
+
+      expect(result.success).toBe(false);
+      expect(
+        result.error?.issues.some((issue) => issue.message.includes('raw board resource id'))
+      ).toBe(true);
+    });
+  });
+
+  describe('yuque_create_resource', () => {
+    it('should create a board resource', async () => {
+      (mockClient.createResource as ReturnType<typeof vi.fn>).mockResolvedValue(mockBoardResult);
+
+      const result = await resourceTools.yuque_create_resource.handler(mockClient, {
+        resource_type: 'board',
+        doc_id: 1,
+        type: 'mindmap',
+        dsl: '- root',
+        insert_after_lake_id: 'lake-1',
+      } as never);
+
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed.board.resource.kind).toBe('mindmap');
+      expect(mockClient.createResource).toHaveBeenCalledWith({
+        resource_type: 'board',
+        doc_id: 1,
+        type: 'mindmap',
+        dsl: '- root',
+        insert_after_lake_id: 'lake-1',
+      });
+    });
+
+    it('should reject when doc_id and url are missing', () => {
+      const result = resourceTools.yuque_create_resource.inputSchema.safeParse({
+        resource_type: 'board',
+        type: 'mindmap',
+        dsl: '- root',
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error?.issues.some((issue) => issue.message.includes('doc_id or url'))).toBe(
+        true
+      );
+    });
+  });
+
+  describe('yuque_update_resource', () => {
+    it('should update a board resource with text DSL', async () => {
+      (mockClient.updateResource as ReturnType<typeof vi.fn>).mockResolvedValue(mockBoardResult);
+
+      const result = await resourceTools.yuque_update_resource.handler(mockClient, {
+        resource_type: 'board',
+        doc_id: 1,
+        resource_id: 'board-1',
+        text: '- next',
+      } as never);
+
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed.board.resource.id).toBe('board-1');
+      expect(mockClient.updateResource).toHaveBeenCalledWith({
+        resource_type: 'board',
+        doc_id: 1,
+        resource_id: 'board-1',
+        text: '- next',
+      });
+    });
+
+    it('should update a board resource with JSON DSL', async () => {
+      const nextDsl = {
+        value: {
+          diagramData: {
+            body: [],
+          },
+        },
+        format: 'json',
+        language: 'json',
+      };
+      (mockClient.updateResource as ReturnType<typeof vi.fn>).mockResolvedValue({
+        ...mockBoardResult,
+        board: {
+          ...mockBoardResult.board,
+          dsl: nextDsl,
+        },
+      });
+
+      const result = await resourceTools.yuque_update_resource.handler(mockClient, {
+        resource_type: 'board',
+        url: 'https://www.yuque.com/user/repo/doc',
+        resource_id: 'board-1',
+        dsl: nextDsl,
+      } as never);
+
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed.board.dsl.format).toBe('json');
+      expect(mockClient.updateResource).toHaveBeenCalledWith({
+        resource_type: 'board',
+        url: 'https://www.yuque.com/user/repo/doc',
+        resource_id: 'board-1',
+        dsl: nextDsl,
+      });
+    });
+
+    it('should reject update with both text and dsl', () => {
+      const result = resourceTools.yuque_update_resource.inputSchema.safeParse({
+        resource_type: 'board',
+        doc_id: 1,
+        resource_id: 'board-1',
+        text: '- root',
+        dsl: { format: 'json', language: 'json', value: {} },
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error?.issues.some((issue) => issue.message.includes('text or dsl'))).toBe(
+        true
+      );
+    });
+
+    it('should reject update without text or dsl', () => {
+      const result = resourceTools.yuque_update_resource.inputSchema.safeParse({
+        resource_type: 'board',
+        doc_id: 1,
+        resource_id: 'board-1',
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error?.issues.some((issue) => issue.message.includes('text or dsl'))).toBe(
+        true
+      );
+    });
+  });
+});


### PR DESCRIPTION
### What does this PR do?

Adds YMD-compatible markdown document read/write routing and board resource tools while keeping the MCP user workflow simple.

- Add `YuqueClient.getYmdDoc` and `YuqueClient.updateYmdDoc` for `/api/v2/yfm/docs`.
- Route default/`markdown` `yuque_get_doc` body reads through YMD after resolving the document with the existing public v2 document API.
- Route default/`markdown` `yuque_update_doc` body writes through YMD, while keeping title/slug/public metadata updates on the existing public v2 document API.
- Preserve explicit `lake`/`html` behavior on the legacy document API, and keep `yuque_create_doc` unchanged.
- Add `yuque_get_resource`, `yuque_create_resource`, and `yuque_update_resource` for board resources through `/api/v2/yfm/boards`.
- Keep `resource_type=board` as MCP-side routing only; callers pass raw `resource_id`, while the client maps it to the public v2 `src` field required by the current endpoint.

Validation performed:

- `npm test`
- `npm run typecheck`
- `npm run lint`
- `git diff --check`
- Real-document smoke test for YMD read/write: read, polished, updated, and read back `https://www.yuque.com/alipaydeg9yfphnd/baiz4g/fst7qfkpkiqbnkkc`.
- Real-document smoke test for board resources on the same document: create mindmap board, get resource, update resource text DSL, get again, then restore original document body.

### Related Issues

N/A

### Type of Change

- [ ] 🐞 Bug fix
- [x] ✨ New feature
- [x] 📝 Documentation update
- [ ] ♻️ Refactoring
- [ ] ⚡️ Performance improvement

### Checklist

- [x] Tests added / updated
- [x] Documentation updated (if applicable)
- [x] Changelog entry added (if user-facing)
- [x] No breaking changes (or documented in description)

### Changelog Entry

- Add YMD-compatible markdown read/write routing for `yuque_get_doc` and `yuque_update_doc` while preserving legacy `lake`/`html` behavior.
- Add board resource tools for reading, creating, and updating YFM board cards.
