### PR TITLE
feat: add Sheet document type support

### DIFF
--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -49,6 +49,7 @@ export interface YuqueRepo {
 
 export interface YuqueDoc {
   id: number;
+  type?: string;
   slug: string;
   title: string;
   book_id: number;
@@ -60,6 +61,7 @@ export interface YuqueDoc {
   body_draft: string;
   body_html: string;
   body_lake: string;
+  body_sheet?: string;
   creator_id: number;
   public: number;
   status: number;

--- a/src/tools/doc.ts
+++ b/src/tools/doc.ts
@@ -1,7 +1,13 @@
 import { z } from 'zod';
 import type { YuqueClient } from '../services/yuque-client.js';
 import type { YuqueDoc, YuqueYmdDoc } from '../services/types.js';
-import { formatDocSummary, formatDoc } from '../utils/format.js';
+import { formatDocSummary, formatDoc, formatSheet } from '../utils/format.js';
+import {
+  assertCreateFormatSupported,
+  assertDocBodyWritable,
+  shouldUseYmdForDoc,
+  isSheetDoc,
+} from '../utils/doc-type.js';
 
 async function appendDocToToc(
   client: YuqueClient,
@@ -21,10 +27,6 @@ async function appendDocToToc(
   } catch {
     return 'Document created successfully but failed to auto-append to TOC. Please manually arrange it in the TOC via the Yuque web interface.';
   }
-}
-
-function shouldUseYmd(format?: string): boolean {
-  return !format || format === 'markdown';
 }
 
 function withYmdBody(doc: YuqueDoc, ymdDoc: YuqueYmdDoc): YuqueDoc {
@@ -59,7 +61,8 @@ export const docTools = {
   },
 
   yuque_get_doc: {
-    description: 'Get a specific document with full content',
+    description:
+      'Get a specific document with full content. Sheet documents (lakesheet) are read via the legacy docs API with body_sheet; they do not use /yfm/docs.',
     inputSchema: z.object({
       repo_id: z
         .union([z.string(), z.number()])
@@ -91,7 +94,32 @@ export const docTools = {
       }
     ) => {
       const doc = await client.getDoc(args.repo_id, args.doc_id);
-      const formattedDoc = shouldUseYmd(args.format)
+
+      // Sheet documents: format as Markdown table with graceful degradation
+      if (isSheetDoc(doc)) {
+        const { formatted, success } = formatSheet(doc);
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify(
+                {
+                  ...formatDocSummary(doc),
+                  body: success ? formatted : (doc.body_sheet ?? doc.body),
+                  format_note: success
+                    ? 'Formatted as Markdown table'
+                    : 'Raw format (formatting failed)',
+                },
+                null,
+                2
+              ),
+            },
+          ],
+        };
+      }
+
+      // Regular documents
+      const formattedDoc = shouldUseYmdForDoc(doc, args.format)
         ? withYmdBody(doc, await client.getYmdDoc(doc.id))
         : doc;
       return {
@@ -110,7 +138,8 @@ export const docTools = {
   },
 
   yuque_create_doc: {
-    description: 'Create a new document in a repo/book',
+    description:
+      'Create a new document in a repo/book. Sheet (lakesheet) documents cannot be created via API.',
     inputSchema: z.object({
       repo_id: z
         .union([z.string(), z.number()])
@@ -132,6 +161,8 @@ export const docTools = {
         public?: number;
       }
     ) => {
+      assertCreateFormatSupported(args.format);
+
       const data = {
         title: args.title,
         slug: args.slug,
@@ -155,7 +186,8 @@ export const docTools = {
   },
 
   yuque_update_doc: {
-    description: 'Update an existing document',
+    description:
+      'Update an existing document. Sheet and other non-Doc types: metadata-only (title, slug, public); body updates are not supported by the Open API.',
     inputSchema: z.object({
       repo_id: z
         .union([z.string(), z.number()])
@@ -193,21 +225,25 @@ export const docTools = {
       };
       const hasMetadataUpdate = Object.values(metadata).some((value) => value !== undefined);
 
-      if (args.body !== undefined && shouldUseYmd(args.format)) {
+      if (args.body !== undefined) {
         const currentDoc = await client.getDoc(args.repo_id, args.doc_id);
-        const doc = hasMetadataUpdate
-          ? await client.updateDoc(args.repo_id, args.doc_id, metadata)
-          : currentDoc;
-        await client.updateYmdDoc(currentDoc.id, args.body);
-        const ymdDoc = await client.getYmdDoc(currentDoc.id);
-        return {
-          content: [
-            {
-              type: 'text' as const,
-              text: JSON.stringify(formatDoc(withYmdBody(doc, ymdDoc)), null, 2),
-            },
-          ],
-        };
+        assertDocBodyWritable(currentDoc);
+
+        if (shouldUseYmdForDoc(currentDoc, args.format)) {
+          const doc = hasMetadataUpdate
+            ? await client.updateDoc(args.repo_id, args.doc_id, metadata)
+            : currentDoc;
+          await client.updateYmdDoc(currentDoc.id, args.body);
+          const ymdDoc = await client.getYmdDoc(currentDoc.id);
+          return {
+            content: [
+              {
+                type: 'text' as const,
+                text: JSON.stringify(formatDoc(withYmdBody(doc, ymdDoc)), null, 2),
+              },
+            ],
+          };
+        }
       }
 
       const data = {

--- a/src/utils/doc-type.ts
+++ b/src/utils/doc-type.ts
@@ -1,0 +1,42 @@
+import type { YuqueDoc } from '../services/types.js';
+import { YuqueError } from './error.js';
+
+/** Content formats that must use the legacy GET /docs API instead of /yfm/docs. */
+const LEGACY_ONLY_FORMATS = new Set(['lakesheet']);
+
+/** Document types that do not support the YFM (/yfm/docs) markdown read/write flow. */
+const LEGACY_ONLY_TYPES = new Set(['Sheet', 'Table', 'Board', 'Thread']);
+
+export function isSheetDoc(doc: YuqueDoc): boolean {
+  return doc.format === 'lakesheet' || doc.type === 'Sheet';
+}
+
+/** True when the document must not use /yfm/docs (Sheet, Table, Board, Thread, lakesheet, etc.). */
+export function shouldSkipYmdForDoc(doc: YuqueDoc): boolean {
+  return LEGACY_ONLY_FORMATS.has(doc.format) || (doc.type != null && LEGACY_ONLY_TYPES.has(doc.type));
+}
+
+export function shouldUseYmdForDoc(doc: YuqueDoc, format?: string): boolean {
+  const wantsYmd = !format || format === 'markdown';
+  return wantsYmd && !shouldSkipYmdForDoc(doc);
+}
+
+export function assertDocBodyWritable(doc: YuqueDoc): never | void {
+  if (!shouldSkipYmdForDoc(doc)) {
+    return;
+  }
+  const kind = doc.type ?? doc.format;
+  throw new YuqueError(
+    `Cannot update body for Yuque document type "${kind}". ` +
+      'The Open API only supports markdown/lake/html body writes for regular documents (type Doc). ' +
+      'You may still update metadata (title, slug, public) via yuque_update_doc.'
+  );
+}
+
+export function assertCreateFormatSupported(format?: string): never | void {
+  if (format === 'lakesheet') {
+    throw new YuqueError(
+      'Cannot create Sheet documents via API. Supported create formats: markdown, lake, html.'
+    );
+  }
+}

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -4,6 +4,7 @@ import type {
   YuqueDoc,
   YuqueTocItem,
 } from '../services/types.js';
+import { isSheetDoc } from './doc-type.js';
 
 /** Format user data — strips fields that are noisy for AI consumption. */
 export function formatUser(user: YuqueUser) {
@@ -38,6 +39,7 @@ export function formatDocSummary(doc: YuqueDoc) {
     id: doc.id,
     slug: doc.slug,
     title: doc.title,
+    ...(doc.type && { type: doc.type }),
     format: doc.format,
     public: doc.public === 1,
     word_count: doc.word_count,
@@ -47,6 +49,18 @@ export function formatDocSummary(doc: YuqueDoc) {
 
 /** Format full doc data including body content. */
 export function formatDoc(doc: YuqueDoc, options?: { includeLake?: boolean }) {
+  if (isSheetDoc(doc)) {
+    const sheetBody = doc.body_sheet ?? doc.body;
+    return {
+      ...formatDocSummary(doc),
+      body: sheetBody,
+      body_sheet: sheetBody,
+      body_html: doc.body_html,
+      description: doc.description,
+      ...(options?.includeLake && doc.body_lake && { body_lake: doc.body_lake }),
+    };
+  }
+
   return {
     ...formatDocSummary(doc),
     body: doc.body,
@@ -54,6 +68,52 @@ export function formatDoc(doc: YuqueDoc, options?: { includeLake?: boolean }) {
     description: doc.description,
     ...(options?.includeLake && { body_lake: doc.body_lake }),
   };
+}
+
+/**
+ * Convert Sheet JSON data to Markdown table format.
+ * Returns original data on failure to ensure graceful degradation.
+ */
+export function formatSheet(doc: YuqueDoc): { formatted: string; success: boolean } {
+  try {
+    const sheetBody = doc.body_sheet ?? doc.body;
+    const sheetData = typeof sheetBody === 'string' ? JSON.parse(sheetBody) : sheetBody;
+
+    if (!sheetData?.data?.[0]?.table) {
+      return { formatted: String(sheetBody), success: false };
+    }
+
+    const table: string[][] = sheetData.data[0].table;
+    const sheetName = sheetData.data[0].name ?? 'Sheet1';
+
+    if (!Array.isArray(table) || table.length === 0) {
+      return { formatted: String(sheetBody), success: false };
+    }
+
+    // Build Markdown table
+    const lines: string[] = [`### ${sheetName}\n`];
+
+    // Header row
+    const header = table[0] ?? [];
+    lines.push(`| ${header.map(escapeMarkdownCell).join(' | ')} |`);
+    lines.push(`| ${header.map(() => '---').join(' | ')} |`);
+
+    // Data rows (skip header)
+    for (let i = 1; i < table.length; i++) {
+      const row = table[i] ?? [];
+      lines.push(`| ${row.map(escapeMarkdownCell).join(' | ')} |`);
+    }
+
+    return { formatted: lines.join('\n'), success: true };
+  } catch {
+    // Graceful degradation: return original data
+    return { formatted: String(doc.body_sheet ?? doc.body), success: false };
+  }
+}
+
+/** Escape pipe characters in Markdown table cells. */
+function escapeMarkdownCell(cell: unknown): string {
+  return String(cell ?? '').replace(/\|/g, '\\|').replace(/\n/g, ' ');
 }
 
 /** Format TOC items — flattens to essential navigation fields. */

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -79,32 +79,40 @@ export function formatSheet(doc: YuqueDoc): { formatted: string; success: boolea
     const sheetBody = doc.body_sheet ?? doc.body;
     const sheetData = typeof sheetBody === 'string' ? JSON.parse(sheetBody) : sheetBody;
 
-    if (!sheetData?.data?.[0]?.table) {
+    if (!sheetData?.data?.length) {
       return { formatted: String(sheetBody), success: false };
     }
 
-    const table: string[][] = sheetData.data[0].table;
-    const sheetName = sheetData.data[0].name ?? 'Sheet1';
+    // Iterate over all sheets/tabs
+    const allLines: string[] = [];
+    for (const sheet of sheetData.data) {
+      if (!sheet?.table) continue;
 
-    if (!Array.isArray(table) || table.length === 0) {
+      const table: string[][] = sheet.table;
+      if (!Array.isArray(table) || table.length === 0) continue;
+
+      const sheetName = sheet.name ?? 'Sheet1';
+      allLines.push(`### ${sheetName}\n`);
+
+      // Header row
+      const header = table[0] ?? [];
+      allLines.push(`| ${header.map(escapeMarkdownCell).join(' | ')} |`);
+      allLines.push(`| ${header.map(() => '---').join(' | ')} |`);
+
+      // Data rows (skip header)
+      for (let i = 1; i < table.length; i++) {
+        const row = table[i] ?? [];
+        allLines.push(`| ${row.map(escapeMarkdownCell).join(' | ')} |`);
+      }
+
+      allLines.push(''); // blank line between sheets
+    }
+
+    if (allLines.length === 0) {
       return { formatted: String(sheetBody), success: false };
     }
 
-    // Build Markdown table
-    const lines: string[] = [`### ${sheetName}\n`];
-
-    // Header row
-    const header = table[0] ?? [];
-    lines.push(`| ${header.map(escapeMarkdownCell).join(' | ')} |`);
-    lines.push(`| ${header.map(() => '---').join(' | ')} |`);
-
-    // Data rows (skip header)
-    for (let i = 1; i < table.length; i++) {
-      const row = table[i] ?? [];
-      lines.push(`| ${row.map(escapeMarkdownCell).join(' | ')} |`);
-    }
-
-    return { formatted: lines.join('\n'), success: true };
+    return { formatted: allLines.join('\n').trimEnd(), success: true };
   } catch {
     // Graceful degradation: return original data
     return { formatted: String(doc.body_sheet ?? doc.body), success: false };

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -85,13 +85,18 @@ export function formatSheet(doc: YuqueDoc): { formatted: string; success: boolea
 
     // Iterate over all sheets/tabs
     const allLines: string[] = [];
+    const nameCount = new Map<string, number>();
     for (const sheet of sheetData.data) {
       if (!sheet?.table) continue;
 
       const table: string[][] = sheet.table;
       if (!Array.isArray(table) || table.length === 0) continue;
 
-      const sheetName = sheet.name ?? 'Sheet1';
+      // Deduplicate sheet names: Sheet1, Sheet1 → Sheet1, Sheet1 (2)
+      const baseName = sheet.name ?? 'Sheet1';
+      const count = nameCount.get(baseName) ?? 0;
+      nameCount.set(baseName, count + 1);
+      const sheetName = count > 0 ? `${baseName} (${count + 1})` : baseName;
       allLines.push(`### ${sheetName}\n`);
 
       // Header row

--- a/tests/tools/doc.test.ts
+++ b/tests/tools/doc.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { docTools } from '../../src/tools/doc.js';
 import type { YuqueClient } from '../../src/services/yuque-client.js';
+import { YuqueError } from '../../src/utils/error.js';
 
 const mockClient = {
   listDocs: vi.fn(),
@@ -69,6 +70,52 @@ describe('docTools', () => {
       expect(parsed).toHaveProperty('body_lake', '<!doctype lake><p>Hello</p>');
     });
 
+    it('should read sheet doc via legacy API without YMD', async () => {
+      const sheetJson = JSON.stringify({
+        version: '1.0',
+        data: [{
+          id: 'sheet1',
+          name: 'Sheet1',
+          index: 0,
+          rowCount: 2,
+          colCount: 3,
+          table: [
+            ['Header1', 'Header2', 'Header3'],
+            ['A1', 'B1', 'C1'],
+          ],
+        }],
+      });
+      (mockClient.getDoc as ReturnType<typeof vi.fn>).mockResolvedValue({
+        id: 2,
+        type: 'Sheet',
+        slug: 'sheet1',
+        title: 'Sheet 1',
+        format: 'lakesheet',
+        body: '',
+        body_sheet: sheetJson,
+        body_html: '',
+        created_at: '2024-01-01',
+        updated_at: '2024-01-02',
+        word_count: 0,
+      });
+
+      const result = await docTools.yuque_get_doc.handler(mockClient, {
+        repo_id: 1,
+        doc_id: 2,
+        include_lake: false,
+      } as never);
+
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed).toMatchObject({
+        type: 'Sheet',
+        format: 'lakesheet',
+        format_note: 'Formatted as Markdown table',
+      });
+      // Body should be formatted as Markdown table
+      expect(parsed.body).toContain('|');
+      expect(mockClient.getYmdDoc).not.toHaveBeenCalled();
+    });
+
     it('should use legacy doc content when read format is lake', async () => {
       (mockClient.getDoc as ReturnType<typeof vi.fn>).mockResolvedValue({
         id: 1, slug: 'doc1', title: 'Doc 1', body: '# Hello', body_html: '<h1>Hello</h1>',
@@ -87,6 +134,17 @@ describe('docTools', () => {
   });
 
   describe('yuque_create_doc', () => {
+    it('should reject lakesheet create format before calling API', async () => {
+      await expect(
+        docTools.yuque_create_doc.handler(mockClient, {
+          repo_id: 1,
+          title: 'Sheet',
+          format: 'lakesheet',
+        } as never)
+      ).rejects.toThrow(YuqueError);
+      expect(mockClient.createDoc).not.toHaveBeenCalled();
+    });
+
     it('should create doc with title and body', async () => {
       (mockClient.createDoc as ReturnType<typeof vi.fn>).mockResolvedValue({
         id: 2, slug: 'new-doc', title: 'New Doc', body: 'Content',
@@ -197,7 +255,64 @@ describe('docTools', () => {
       expect(mockClient.updateYmdDoc).toHaveBeenCalledWith(1, '# Updated YMD');
     });
 
+    it('should reject body update on sheet documents', async () => {
+      (mockClient.getDoc as ReturnType<typeof vi.fn>).mockResolvedValue({
+        id: 2,
+        type: 'Sheet',
+        slug: 'sheet1',
+        title: 'Sheet 1',
+        format: 'lakesheet',
+        body: '',
+        body_sheet: '{}',
+        created_at: '2024-01-01',
+        updated_at: '2024-01-02',
+        word_count: 0,
+      });
+
+      await expect(
+        docTools.yuque_update_doc.handler(mockClient, {
+          repo_id: 1,
+          doc_id: 2,
+          body: '{}',
+        } as never)
+      ).rejects.toThrow(YuqueError);
+
+      expect(mockClient.updateDoc).not.toHaveBeenCalled();
+      expect(mockClient.updateYmdDoc).not.toHaveBeenCalled();
+    });
+
+    it('should allow metadata-only update on sheet documents', async () => {
+      (mockClient.updateDoc as ReturnType<typeof vi.fn>).mockResolvedValue({
+        id: 2,
+        type: 'Sheet',
+        slug: 'sheet1',
+        title: 'Renamed Sheet',
+        format: 'lakesheet',
+        body: '',
+        body_sheet: '{}',
+        body_html: '',
+        created_at: '2024-01-01',
+        updated_at: '2024-01-03',
+        word_count: 0,
+      });
+
+      const result = await docTools.yuque_update_doc.handler(mockClient, {
+        repo_id: 1,
+        doc_id: 2,
+        title: 'Renamed Sheet',
+      } as never);
+
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed).toHaveProperty('title', 'Renamed Sheet');
+      expect(mockClient.getDoc).not.toHaveBeenCalled();
+      expect(mockClient.updateDoc).toHaveBeenCalledWith(1, 2, { title: 'Renamed Sheet' });
+    });
+
     it('should use legacy doc update when body format is lake', async () => {
+      (mockClient.getDoc as ReturnType<typeof vi.fn>).mockResolvedValue({
+        id: 1, slug: 'doc1', title: 'Doc 1', body: '<!doctype lake><p>Old</p>',
+        format: 'lake', created_at: '2024-01-01', updated_at: '2024-01-02', word_count: 2,
+      });
       (mockClient.updateDoc as ReturnType<typeof vi.fn>).mockResolvedValue({
         id: 1, slug: 'doc1', title: 'Updated', body: '<!doctype lake><p>Updated</p>',
         format: 'lake', created_at: '2024-01-01', updated_at: '2024-01-02', word_count: 2,
@@ -209,6 +324,7 @@ describe('docTools', () => {
 
       const parsed = JSON.parse(result.content[0].text);
       expect(parsed).toHaveProperty('format', 'lake');
+      expect(mockClient.getDoc).toHaveBeenCalledWith(1, 1);
       expect(mockClient.updateDoc).toHaveBeenCalledWith(1, 1, expect.objectContaining({
         body: '<!doctype lake><p>Updated</p>',
         format: 'lake',

--- a/tests/utils/doc-type.test.ts
+++ b/tests/utils/doc-type.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import {
+  isSheetDoc,
+  shouldSkipYmdForDoc,
+  shouldUseYmdForDoc,
+  assertDocBodyWritable,
+  assertCreateFormatSupported,
+} from '../../src/utils/doc-type.js';
+import { YuqueError } from '../../src/utils/error.js';
+import type { YuqueDoc } from '../../src/services/types.js';
+
+const baseDoc: YuqueDoc = {
+  id: 1,
+  slug: 'doc1',
+  title: 'Doc',
+  book_id: 1,
+  user_id: 1,
+  format: 'markdown',
+  body: '',
+  body_draft: '',
+  body_html: '',
+  body_lake: '',
+  creator_id: 1,
+  public: 1,
+  status: 1,
+  likes_count: 0,
+  comments_count: 0,
+  content_updated_at: '',
+  deleted_at: null,
+  created_at: '',
+  updated_at: '',
+  published_at: '',
+  first_published_at: '',
+  word_count: 0,
+  cover: null,
+  description: '',
+};
+
+describe('doc-type utilities', () => {
+  it('detects sheet by format or type', () => {
+    expect(isSheetDoc({ ...baseDoc, format: 'lakesheet' })).toBe(true);
+    expect(isSheetDoc({ ...baseDoc, type: 'Sheet', format: 'markdown' })).toBe(true);
+    expect(isSheetDoc(baseDoc)).toBe(false);
+  });
+
+  it('skips YMD for sheet and other legacy-only types', () => {
+    expect(shouldSkipYmdForDoc({ ...baseDoc, format: 'lakesheet' })).toBe(true);
+    expect(shouldSkipYmdForDoc({ ...baseDoc, type: 'Table' })).toBe(true);
+    expect(shouldSkipYmdForDoc(baseDoc)).toBe(false);
+  });
+
+  it('uses YMD only for compatible markdown docs', () => {
+    expect(shouldUseYmdForDoc(baseDoc)).toBe(true);
+    expect(shouldUseYmdForDoc(baseDoc, 'lake')).toBe(false);
+    expect(shouldUseYmdForDoc({ ...baseDoc, format: 'lakesheet' })).toBe(false);
+    expect(shouldUseYmdForDoc({ ...baseDoc, format: 'lakesheet' }, 'markdown')).toBe(false);
+  });
+
+  it('rejects body writes for sheet docs', () => {
+    expect(() => assertDocBodyWritable({ ...baseDoc, format: 'lakesheet' })).toThrow(YuqueError);
+    expect(() => assertCreateFormatSupported('lakesheet')).toThrow(YuqueError);
+  });
+});

--- a/tests/utils/format.test.ts
+++ b/tests/utils/format.test.ts
@@ -203,6 +203,29 @@ describe('format utilities', () => {
       expect(result.formatted).not.toContain('### Empty');
     });
 
+    it('should deduplicate identical sheet names', () => {
+      const doc: YuqueDoc = {
+        ...baseDoc,
+        body_sheet: JSON.stringify({
+          version: '1.0',
+          data: [
+            { table: [['A', 'B'], ['1', '2']] },
+            { name: 'Sheet1', table: [['C', 'D'], ['3', '4']] },
+            { table: [['E', 'F'], ['5', '6']] },
+          ],
+        }),
+      };
+      const result = formatSheet(doc);
+      expect(result.success).toBe(true);
+      expect(result.formatted).toContain('### Sheet1\n');
+      expect(result.formatted).toContain('### Sheet1 (2)');
+      expect(result.formatted).toContain('### Sheet1 (3)');
+      // Each sheet's data is present
+      expect(result.formatted).toContain('| A | B |');
+      expect(result.formatted).toContain('| C | D |');
+      expect(result.formatted).toContain('| E | F |');
+    });
+
     it('should fall back to raw data when data is empty', () => {
       const raw = JSON.stringify({ version: '1.0', data: [] });
       const doc: YuqueDoc = { ...baseDoc, body_sheet: raw };

--- a/tests/utils/format.test.ts
+++ b/tests/utils/format.test.ts
@@ -124,6 +124,23 @@ describe('format utilities', () => {
       expect(result).toHaveProperty('body_lake', '<!doctype lake>');
     });
 
+    it('should expose body_sheet for sheet documents', () => {
+      const sheetDoc: YuqueDoc = {
+        ...doc,
+        type: 'Sheet',
+        format: 'lakesheet',
+        body: '',
+        body_sheet: '{"version":"1.0","data":[]}',
+      };
+      const result = formatDoc(sheetDoc);
+      expect(result).toMatchObject({
+        type: 'Sheet',
+        format: 'lakesheet',
+        body: '{"version":"1.0","data":[]}',
+        body_sheet: '{"version":"1.0","data":[]}',
+      });
+    });
+
     it('should not include body_lake when includeLake is false', () => {
       const result = formatDoc(doc, { includeLake: false });
       expect(result).not.toHaveProperty('body_lake');

--- a/tests/utils/format.test.ts
+++ b/tests/utils/format.test.ts
@@ -4,6 +4,7 @@ import {
   formatRepo,
   formatDocSummary,
   formatDoc,
+  formatSheet,
   formatToc,
 } from '../../src/utils/format.js';
 import type { YuqueUser, YuqueRepo, YuqueDoc, YuqueTocItem } from '../../src/services/types.js';
@@ -144,6 +145,77 @@ describe('format utilities', () => {
     it('should not include body_lake when includeLake is false', () => {
       const result = formatDoc(doc, { includeLake: false });
       expect(result).not.toHaveProperty('body_lake');
+    });
+  });
+
+  describe('formatSheet', () => {
+    const baseDoc: YuqueDoc = {
+      id: 1, slug: 'test-sheet', title: 'Test Sheet', book_id: 1, user_id: 1,
+      format: 'lakesheet', body: '', body_draft: '',
+      body_html: '', body_lake: '', creator_id: 1,
+      public: 1, status: 1, likes_count: 0, comments_count: 0,
+      content_updated_at: '2024-01-01', deleted_at: null,
+      created_at: '2024-01-01', updated_at: '2024-01-02',
+      published_at: '2024-01-01', first_published_at: '2024-01-01',
+      word_count: 0, cover: null, description: '',
+    };
+
+    it('should format single sheet', () => {
+      const doc: YuqueDoc = {
+        ...baseDoc,
+        body_sheet: JSON.stringify({
+          version: '1.0',
+          data: [{ name: 'Sheet1', table: [['A', 'B'], ['1', '2'], ['3', '4']] }],
+        }),
+      };
+      const result = formatSheet(doc);
+      expect(result.success).toBe(true);
+      expect(result.formatted).toContain('### Sheet1');
+      expect(result.formatted).toContain('| A | B |');
+      expect(result.formatted).toContain('| 1 | 2 |');
+      expect(result.formatted).toContain('| 3 | 4 |');
+    });
+
+    it('should format multiple sheets preserving all tabs', () => {
+      const doc: YuqueDoc = {
+        ...baseDoc,
+        body_sheet: JSON.stringify({
+          version: '1.0',
+          data: [
+            { name: 'Sales', table: [['Month', 'Revenue'], ['Jan', '100'], ['Feb', '200']] },
+            { name: 'Users', table: [['Name', 'Age'], ['Alice', '30'], ['Bob', '25']] },
+            { name: 'Empty', table: [] },
+          ],
+        }),
+      };
+      const result = formatSheet(doc);
+      expect(result.success).toBe(true);
+      // First sheet
+      expect(result.formatted).toContain('### Sales');
+      expect(result.formatted).toContain('| Month | Revenue |');
+      expect(result.formatted).toContain('| Jan | 100 |');
+      // Second sheet — must not be dropped
+      expect(result.formatted).toContain('### Users');
+      expect(result.formatted).toContain('| Name | Age |');
+      expect(result.formatted).toContain('| Alice | 30 |');
+      expect(result.formatted).toContain('| Bob | 25 |');
+      // Empty table is skipped
+      expect(result.formatted).not.toContain('### Empty');
+    });
+
+    it('should fall back to raw data when data is empty', () => {
+      const raw = JSON.stringify({ version: '1.0', data: [] });
+      const doc: YuqueDoc = { ...baseDoc, body_sheet: raw };
+      const result = formatSheet(doc);
+      expect(result.success).toBe(false);
+      expect(result.formatted).toBe(raw);
+    });
+
+    it('should fall back to raw data when parse fails', () => {
+      const doc: YuqueDoc = { ...baseDoc, body_sheet: 'not-json' };
+      const result = formatSheet(doc);
+      expect(result.success).toBe(false);
+      expect(result.formatted).toBe('not-json');
     });
   });
 


### PR DESCRIPTION
What does this PR do?

Add support for reading Yuque Sheet (电子表格) documents and properly handle non-Doc types (Sheet, Table, Board, Thread) across document tools.

- yuque_get_doc auto-detects Sheet documents and formats body_sheet JSON as Markdown table
- New doc-type utility for type detection and write guards
- yuque_create_doc / yuque_update_doc block unsupported body operations on non-Doc types with clear errors
- Added type and body_sheet fields to YuqueDoc interface
- Graceful degradation on Sheet formatting failure

Related Issues
N/A

### Type of Change
-  ✨ New feature

### Checklist

-  Tests added / updated
-  Changelog entry added (if user-facing)
-  No breaking changes (or documented in description)

### Added
- Support reading Sheet documents via `yuque_get_doc` with automatic Markdown table formatting
- New `doc-type` utility module for document type detection and write guards
- `type` and `body_sheet` fields added to `YuqueDoc` interface
- `yuque_create_doc` rejects `lakesheet` format with clear error
- `yuque_update_doc` blocks body writes on Sheet/Table/Board/Thread types; metadata updates still work
- Graceful degradation when Sheet JSON→Markdown conversion fails