### PR TITLE
[codex] reach 100 percent line coverage

### DIFF
--- a/src/cli-install.ts
+++ b/src/cli-install.ts
@@ -5,7 +5,15 @@ import * as readline from 'node:readline';
 
 // ─── Client Definitions ───────────────────────────────────────────────
 
-type ClientId = 'claude-desktop' | 'vscode' | 'cursor' | 'windsurf' | 'cline' | 'trae' | 'qoder' | 'opencode';
+type ClientId =
+  | 'claude-desktop'
+  | 'vscode'
+  | 'cursor'
+  | 'windsurf'
+  | 'cline'
+  | 'trae'
+  | 'qoder'
+  | 'opencode';
 
 interface ClientConfig {
   name: string;
@@ -16,10 +24,7 @@ interface ClientConfig {
 }
 
 function getAppDataPath(): string {
-  if (process.platform === 'win32') {
-    return process.env.APPDATA || path.join(os.homedir(), 'AppData', 'Roaming');
-  }
-  return '';
+  return process.env.APPDATA || path.join(os.homedir(), 'AppData', 'Roaming');
 }
 
 function getConfigHome(): string {
@@ -36,11 +41,21 @@ const CLIENT_CONFIGS: Record<ClientId, ClientConfig> = {
     getConfigPath() {
       switch (process.platform) {
         case 'darwin':
-          return path.join(os.homedir(), 'Library', 'Application Support', 'Claude', 'claude_desktop_config.json');
+          return path.join(
+            os.homedir(),
+            'Library',
+            'Application Support',
+            'Claude',
+            'claude_desktop_config.json'
+          );
         case 'win32':
           return path.join(getAppDataPath(), 'Claude', 'claude_desktop_config.json');
         default:
-          return path.join(getConfigHome() || path.join(os.homedir(), '.config'), 'Claude', 'claude_desktop_config.json');
+          return path.join(
+            getConfigHome() || path.join(os.homedir(), '.config'),
+            'Claude',
+            'claude_desktop_config.json'
+          );
       }
     },
   },
@@ -111,9 +126,27 @@ const CLIENT_CONFIGS: Record<ClientId, ClientConfig> = {
     getConfigPath() {
       switch (process.platform) {
         case 'darwin':
-          return path.join(os.homedir(), 'Library', 'Application Support', 'Trae', 'User', 'globalStorage', 'trae-ai.trae-core', 'settings', 'cline_mcp_settings.json');
+          return path.join(
+            os.homedir(),
+            'Library',
+            'Application Support',
+            'Trae',
+            'User',
+            'globalStorage',
+            'trae-ai.trae-core',
+            'settings',
+            'cline_mcp_settings.json'
+          );
         case 'win32':
-          return path.join(getAppDataPath(), 'Trae', 'User', 'globalStorage', 'trae-ai.trae-core', 'settings', 'cline_mcp_settings.json');
+          return path.join(
+            getAppDataPath(),
+            'Trae',
+            'User',
+            'globalStorage',
+            'trae-ai.trae-core',
+            'settings',
+            'cline_mcp_settings.json'
+          );
         default:
           return path.join(
             getConfigHome() || path.join(os.homedir(), '.config'),
@@ -241,14 +274,18 @@ export function runInstall(args: string[]): void {
 
   if (!tokenArg) {
     console.error('Error: --token=YOUR_TOKEN is required.');
-    console.error('Usage: npx yuque-mcp install --token=YOUR_TOKEN --client=CLIENT [--base-url=URL]');
+    console.error(
+      'Usage: npx yuque-mcp install --token=YOUR_TOKEN --client=CLIENT [--base-url=URL]'
+    );
     console.error(`Supported clients: ${getSupportedClients().join(', ')}`);
     process.exit(1);
   }
 
   if (!clientArg) {
     console.error('Error: --client=CLIENT is required.');
-    console.error('Usage: npx yuque-mcp install --token=YOUR_TOKEN --client=CLIENT [--base-url=URL]');
+    console.error(
+      'Usage: npx yuque-mcp install --token=YOUR_TOKEN --client=CLIENT [--base-url=URL]'
+    );
     console.error(`Supported clients: ${getSupportedClients().join(', ')}`);
     process.exit(1);
   }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -14,7 +14,9 @@ if (handleCliSubcommands(process.argv)) {
     process.argv.find((arg) => arg.startsWith('--token='))?.split('=')[1];
 
   if (!token) {
-    console.error('Error: YUQUE_PERSONAL_TOKEN environment variable or --token argument is required');
+    console.error(
+      'Error: YUQUE_PERSONAL_TOKEN environment variable or --token argument is required'
+    );
     process.exit(1);
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,9 @@ import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/
 import { createServer } from 'node:http';
 import { randomUUID } from 'node:crypto';
 
-const token = process.env.YUQUE_PERSONAL_TOKEN || process.argv.find((arg) => arg.startsWith('--token='))?.split('=')[1];
+const token =
+  process.env.YUQUE_PERSONAL_TOKEN ||
+  process.argv.find((arg) => arg.startsWith('--token='))?.split('=')[1];
 
 if (!token) {
   console.error('Error: YUQUE_PERSONAL_TOKEN environment variable or --token argument is required');
@@ -19,20 +21,23 @@ const transport = new StreamableHTTPServerTransport({
   sessionIdGenerator: () => randomUUID(),
 });
 
-mcpServer.connect(transport).then(() => {
-  const port = Number(process.env.PORT) || 3000;
-  const httpServer = createServer((req, res) => {
-    transport.handleRequest(req, res).catch((error) => {
-      console.error('Request handling error:', error);
-      res.statusCode = 500;
-      res.end('Internal Server Error');
+mcpServer
+  .connect(transport)
+  .then(() => {
+    const port = Number(process.env.PORT) || 3000;
+    const httpServer = createServer((req, res) => {
+      transport.handleRequest(req, res).catch((error) => {
+        console.error('Request handling error:', error);
+        res.statusCode = 500;
+        res.end('Internal Server Error');
+      });
     });
-  });
 
-  httpServer.listen(port, () => {
-    console.log(`Yuque MCP Server running on http://localhost:${port}`);
+    httpServer.listen(port, () => {
+      console.log(`Yuque MCP Server running on http://localhost:${port}`);
+    });
+  })
+  .catch((error) => {
+    console.error('Failed to start server:', error);
+    process.exit(1);
   });
-}).catch((error) => {
-  console.error('Failed to start server:', error);
-  process.exit(1);
-});

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,9 +1,6 @@
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
-import {
-  CallToolRequestSchema,
-  ListToolsRequestSchema,
-} from '@modelcontextprotocol/sdk/types.js';
+import { CallToolRequestSchema, ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
 import { createRequire } from 'node:module';
 import { zodToJsonSchema } from 'zod-to-json-schema';
 import { YuqueClient } from './services/yuque-client.js';

--- a/src/services/yuque-client.ts
+++ b/src/services/yuque-client.ts
@@ -197,9 +197,16 @@ export class YuqueClient {
   }
 
   /** Update an existing document. */
-  async updateDoc(repoId: string | number, docId: string | number, data: UpdateDocData): Promise<YuqueDoc> {
+  async updateDoc(
+    repoId: string | number,
+    docId: string | number,
+    data: UpdateDocData
+  ): Promise<YuqueDoc> {
     return withErrorHandling(async () => {
-      const r = await this.client.put<YuqueApiResponse<YuqueDoc>>(`/repos/${repoId}/docs/${docId}`, data);
+      const r = await this.client.put<YuqueApiResponse<YuqueDoc>>(
+        `/repos/${repoId}/docs/${docId}`,
+        data
+      );
       return r.data.data;
     });
   }
@@ -267,7 +274,10 @@ export class YuqueClient {
   /** Update the table of contents for a repo. */
   async updateToc(repoId: string | number, data: string): Promise<YuqueTocItem[]> {
     return withErrorHandling(async () => {
-      const r = await this.client.put<YuqueApiResponse<YuqueTocItem[]>>(`/repos/${repoId}/toc`, data);
+      const r = await this.client.put<YuqueApiResponse<YuqueTocItem[]>>(
+        `/repos/${repoId}/toc`,
+        data
+      );
       return r.data.data;
     });
   }
@@ -287,7 +297,9 @@ export class YuqueClient {
   /** Get a specific version of a document. */
   async getDocVersion(versionId: number): Promise<YuqueDocVersion> {
     return withErrorHandling(async () => {
-      const r = await this.client.get<YuqueApiResponse<YuqueDocVersion>>(`/doc_versions/${versionId}`);
+      const r = await this.client.get<YuqueApiResponse<YuqueDocVersion>>(
+        `/doc_versions/${versionId}`
+      );
       return r.data.data;
     });
   }
@@ -297,15 +309,24 @@ export class YuqueClient {
   /** List all members of a group. */
   async listGroupMembers(login: string): Promise<YuqueGroupMember[]> {
     return withErrorHandling(async () => {
-      const r = await this.client.get<YuqueApiResponse<YuqueGroupMember[]>>(`/groups/${login}/users`);
+      const r = await this.client.get<YuqueApiResponse<YuqueGroupMember[]>>(
+        `/groups/${login}/users`
+      );
       return r.data.data;
     });
   }
 
   /** Update a group member's role. */
-  async updateGroupMember(login: string, userId: number, data: { role: number }): Promise<YuqueGroupMember> {
+  async updateGroupMember(
+    login: string,
+    userId: number,
+    data: { role: number }
+  ): Promise<YuqueGroupMember> {
     return withErrorHandling(async () => {
-      const r = await this.client.put<YuqueApiResponse<YuqueGroupMember>>(`/groups/${login}/users/${userId}`, data);
+      const r = await this.client.put<YuqueApiResponse<YuqueGroupMember>>(
+        `/groups/${login}/users/${userId}`,
+        data
+      );
       return r.data.data;
     });
   }
@@ -322,7 +343,9 @@ export class YuqueClient {
   /** Get overall statistics for a group. */
   async getGroupStats(login: string): Promise<YuqueStatistics> {
     return withErrorHandling(async () => {
-      const r = await this.client.get<YuqueApiResponse<YuqueStatistics>>(`/groups/${login}/statistics`);
+      const r = await this.client.get<YuqueApiResponse<YuqueStatistics>>(
+        `/groups/${login}/statistics`
+      );
       return r.data.data;
     });
   }
@@ -330,7 +353,9 @@ export class YuqueClient {
   /** Get member statistics for a group. */
   async getGroupMemberStats(login: string): Promise<unknown> {
     return withErrorHandling(async () => {
-      const r = await this.client.get<YuqueApiResponse<unknown>>(`/groups/${login}/statistics/members`);
+      const r = await this.client.get<YuqueApiResponse<unknown>>(
+        `/groups/${login}/statistics/members`
+      );
       return r.data.data;
     });
   }
@@ -338,7 +363,9 @@ export class YuqueClient {
   /** Get book/repo statistics for a group. */
   async getGroupBookStats(login: string): Promise<unknown> {
     return withErrorHandling(async () => {
-      const r = await this.client.get<YuqueApiResponse<unknown>>(`/groups/${login}/statistics/books`);
+      const r = await this.client.get<YuqueApiResponse<unknown>>(
+        `/groups/${login}/statistics/books`
+      );
       return r.data.data;
     });
   }
@@ -346,7 +373,9 @@ export class YuqueClient {
   /** Get document statistics for a group. */
   async getGroupDocStats(login: string): Promise<unknown> {
     return withErrorHandling(async () => {
-      const r = await this.client.get<YuqueApiResponse<unknown>>(`/groups/${login}/statistics/docs`);
+      const r = await this.client.get<YuqueApiResponse<unknown>>(
+        `/groups/${login}/statistics/docs`
+      );
       return r.data.data;
     });
   }
@@ -386,7 +415,10 @@ export class YuqueClient {
   /** Create a new note. */
   async createNote(data: CreateNoteData): Promise<CreateNoteResponse> {
     return withErrorHandling(async () => {
-      const r = await this.client.post<{ success: boolean; data: CreateNoteResponse }>('/notes', data);
+      const r = await this.client.post<{ success: boolean; data: CreateNoteResponse }>(
+        '/notes',
+        data
+      );
       return r.data.data;
     });
   }

--- a/src/tools/doc.ts
+++ b/src/tools/doc.ts
@@ -64,9 +64,7 @@ export const docTools = {
       repo_id: z
         .union([z.string(), z.number()])
         .describe('Repo ID or namespace (e.g., "mygroup/mybook")'),
-      doc_id: z
-        .union([z.string(), z.number()])
-        .describe('Document ID or slug'),
+      doc_id: z.union([z.string(), z.number()]).describe('Document ID or slug'),
       format: z
         .enum(['markdown', 'lake', 'html'])
         .optional()
@@ -77,9 +75,7 @@ export const docTools = {
         .boolean()
         .optional()
         .default(false)
-        .describe(
-          'Include raw Lake format body (preserves Mermaid source code, diagrams, etc.)'
-        ),
+        .describe('Include raw Lake format body (preserves Mermaid source code, diagrams, etc.)'),
     }),
     handler: async (
       client: YuqueClient,
@@ -160,9 +156,7 @@ export const docTools = {
       repo_id: z
         .union([z.string(), z.number()])
         .describe('Repo ID or namespace (e.g., "mygroup/mybook")'),
-      doc_id: z
-        .union([z.string(), z.number()])
-        .describe('Document ID or slug'),
+      doc_id: z.union([z.string(), z.number()]).describe('Document ID or slug'),
       title: z.string().optional().describe('New document title'),
       slug: z.string().optional().describe('New document slug'),
       body: z.string().optional().describe('New document content'),
@@ -226,5 +220,4 @@ export const docTools = {
       };
     },
   },
-
 };

--- a/src/tools/note.ts
+++ b/src/tools/note.ts
@@ -46,7 +46,10 @@ export const noteTools = {
       page: z.number().optional().describe('Page number (default: 1)'),
       limit: z.number().optional().describe('Number of notes per page (default: 20)'),
     }),
-    handler: async (client: YuqueClient, args: { status?: number; page?: number; limit?: number }) => {
+    handler: async (
+      client: YuqueClient,
+      args: { status?: number; page?: number; limit?: number }
+    ) => {
       const result = await client.listNotes(args.status, args.page, args.limit);
       const allNotes = [...result.pin_notes, ...result.notes];
       return {

--- a/src/tools/search.ts
+++ b/src/tools/search.ts
@@ -6,7 +6,9 @@ export const searchTools = {
     description: 'Search for documents or repos in Yuque',
     inputSchema: z.object({
       query: z.string().describe('Search query string'),
-      type: z.enum(['doc', 'repo']).describe('Search type: doc (documents), repo (knowledge bases)'),
+      type: z
+        .enum(['doc', 'repo'])
+        .describe('Search type: doc (documents), repo (knowledge bases)'),
     }),
     handler: async (client: YuqueClient, args: { query: string; type: 'doc' | 'repo' }) => {
       const result = await client.search(args.query, args.type);

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -12,12 +12,18 @@ export class YuqueError extends Error {
 /** Map common HTTP status codes to human-readable hints for better AI diagnostics. */
 function statusHint(status: number): string {
   switch (status) {
-    case 400: return 'Bad request — check the parameters';
-    case 401: return 'Unauthorized — the API token (YUQUE_PERSONAL_TOKEN) may be invalid or expired';
-    case 403: return 'Forbidden — insufficient permissions for this resource';
-    case 404: return 'Not found — the resource does not exist or is not accessible';
-    case 429: return 'Rate limited — too many requests, try again later';
-    default:  return status >= 500 ? 'Yuque server error — try again later' : '';
+    case 400:
+      return 'Bad request — check the parameters';
+    case 401:
+      return 'Unauthorized — the API token (YUQUE_PERSONAL_TOKEN) may be invalid or expired';
+    case 403:
+      return 'Forbidden — insufficient permissions for this resource';
+    case 404:
+      return 'Not found — the resource does not exist or is not accessible';
+    case 429:
+      return 'Rate limited — too many requests, try again later';
+    default:
+      return status >= 500 ? 'Yuque server error — try again later' : '';
   }
 }
 
@@ -27,7 +33,10 @@ export function handleYuqueError(error: unknown): never {
   }
 
   if (typeof error === 'object' && error !== null) {
-    const err = error as { response?: { status?: number; data?: { message?: string } }; message?: string };
+    const err = error as {
+      response?: { status?: number; data?: { message?: string } };
+      message?: string;
+    };
 
     if (err.response) {
       const status = err.response.status;

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -1,9 +1,4 @@
-import type {
-  YuqueUser,
-  YuqueRepo,
-  YuqueDoc,
-  YuqueTocItem,
-} from '../services/types.js';
+import type { YuqueUser, YuqueRepo, YuqueDoc, YuqueTocItem } from '../services/types.js';
 
 /** Format user data — strips fields that are noisy for AI consumption. */
 export function formatUser(user: YuqueUser) {

--- a/tests/cli-install-setup.test.ts
+++ b/tests/cli-install-setup.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+
+const readlineMock = vi.hoisted(() => ({
+  answers: [] as string[],
+  close: vi.fn(),
+}));
+
+vi.mock('node:readline', () => ({
+  createInterface: vi.fn(() => ({
+    question: vi.fn((_question: string, callback: (answer: string) => void) => {
+      callback(readlineMock.answers.shift() ?? '');
+    }),
+    close: readlineMock.close,
+  })),
+}));
+
+let tmpDir: string;
+let setupImportRun = 0;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'yuque-mcp-setup-test-'));
+  vi.clearAllMocks();
+  readlineMock.answers = [];
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+function mockExit(throws = true) {
+  return vi.spyOn(process, 'exit').mockImplementation((code?: string | number | null) => {
+    if (throws) {
+      throw new Error(`exit:${code}`);
+    }
+    return undefined as never;
+  });
+}
+
+async function importCliInstall() {
+  vi.resetModules();
+  const importers = [
+    () => import('../src/cli-install.js?setup=0'),
+    () => import('../src/cli-install.js?setup=1'),
+    () => import('../src/cli-install.js?setup=2'),
+    () => import('../src/cli-install.js?setup=3'),
+    () => import('../src/cli-install.js?setup=4'),
+  ];
+  const importer = importers[setupImportRun++];
+  if (!importer) throw new Error('No setup import slot left');
+  return importer();
+}
+
+describe('runSetup', () => {
+  it('should install using interactive answers', async () => {
+    const module = await importCliInstall();
+    const configPath = path.join(tmpDir, 'setup', 'claude_desktop_config.json');
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const clientConfig = module.getClientConfig('claude-desktop');
+    if (!clientConfig) throw new Error('claude-desktop config missing');
+    clientConfig.getConfigPath = () => configPath;
+    readlineMock.answers = ['setup-token', '1', 'https://yuque.internal/api/v2'];
+
+    await module.runSetup();
+
+    const content = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+    expect(content.mcpServers.yuque.env).toEqual({
+      YUQUE_PERSONAL_TOKEN: 'setup-token',
+      YUQUE_BASE_URL: 'https://yuque.internal/api/v2',
+    });
+    expect(readlineMock.close).toHaveBeenCalledTimes(1);
+    expect(log).toHaveBeenCalledWith(expect.stringContaining('Successfully configured'));
+  });
+
+  it('should exit when interactive token is empty', async () => {
+    const module = await importCliInstall();
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+    readlineMock.answers = [''];
+    mockExit();
+
+    await expect(module.runSetup()).rejects.toThrow('exit:1');
+    expect(error).toHaveBeenCalledWith('\n❌ Token cannot be empty.\n');
+    expect(readlineMock.close).toHaveBeenCalledTimes(1);
+  });
+
+  it('should exit when interactive client selection is invalid', async () => {
+    const module = await importCliInstall();
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+    readlineMock.answers = ['setup-token', '999'];
+    mockExit();
+
+    await expect(module.runSetup()).rejects.toThrow('exit:1');
+    expect(error).toHaveBeenCalledWith('\n❌ Invalid selection.\n');
+    expect(readlineMock.close).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('handleCliSubcommands setup branch', () => {
+  it('should handle setup subcommand', async () => {
+    const module = await importCliInstall();
+    const configPath = path.join(tmpDir, 'handle-setup', 'claude_desktop_config.json');
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    const clientConfig = module.getClientConfig('claude-desktop');
+    if (!clientConfig) throw new Error('claude-desktop config missing');
+    clientConfig.getConfigPath = () => configPath;
+    readlineMock.answers = ['tok', '1', ''];
+
+    const handled = module.handleCliSubcommands(['node', 'cli.js', 'setup']);
+    for (let i = 0; i < 5; i += 1) {
+      await Promise.resolve();
+    }
+
+    expect(handled).toBe(true);
+    expect(fs.existsSync(configPath)).toBe(true);
+  });
+
+  it('should report setup failures from the async handler', async () => {
+    const module = await importCliInstall();
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const clientConfig = module.getClientConfig('claude-desktop');
+    if (!clientConfig) throw new Error('claude-desktop config missing');
+    clientConfig.getConfigPath = () => {
+      throw new Error('config path failed');
+    };
+    readlineMock.answers = ['tok', '1', ''];
+    mockExit(false);
+
+    const handled = module.handleCliSubcommands(['node', 'cli.js', 'setup']);
+    for (let i = 0; i < 5; i += 1) {
+      await Promise.resolve();
+    }
+
+    expect(handled).toBe(true);
+    expect(error).toHaveBeenCalledWith('Setup failed:', expect.any(Error));
+    expect(process.exit).toHaveBeenCalledWith(1);
+  });
+});

--- a/tests/cli-install.test.ts
+++ b/tests/cli-install.test.ts
@@ -1,18 +1,42 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as os from 'node:os';
-import { installToClient, getSupportedClients, getClientConfig } from '../src/cli-install.js';
+import {
+  installToClient,
+  getSupportedClients,
+  getClientConfig,
+  runInstall,
+  handleCliSubcommands,
+} from '../src/cli-install.js';
 
 // Use a temp directory for all file operations
 let tmpDir: string;
+const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
+const originalAppData = process.env.APPDATA;
+const originalXdgConfigHome = process.env.XDG_CONFIG_HOME;
+const originalGetConfigPaths = new Map(
+  getSupportedClients().map((client) => [client, getClientConfig(client)?.getConfigPath])
+);
 
 beforeEach(() => {
   tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'yuque-mcp-test-'));
+  vi.restoreAllMocks();
+  process.env.APPDATA = originalAppData;
+  process.env.XDG_CONFIG_HOME = originalXdgConfigHome;
 });
 
 afterEach(() => {
   fs.rmSync(tmpDir, { recursive: true, force: true });
+  for (const [client, getConfigPath] of originalGetConfigPaths) {
+    const clientConfig = getClientConfig(client);
+    if (clientConfig && getConfigPath) {
+      clientConfig.getConfigPath = getConfigPath;
+    }
+  }
+  if (originalPlatform) {
+    Object.defineProperty(process, 'platform', originalPlatform);
+  }
 });
 
 /**
@@ -22,6 +46,19 @@ function mockConfigPath(client: string, configPath: string) {
   const clientConfig = getClientConfig(client as never);
   if (!clientConfig) throw new Error(`Unknown client: ${client}`);
   clientConfig.getConfigPath = () => configPath;
+}
+
+function setPlatform(platform: NodeJS.Platform) {
+  Object.defineProperty(process, 'platform', {
+    value: platform,
+    configurable: true,
+  });
+}
+
+function mockExit() {
+  return vi.spyOn(process, 'exit').mockImplementation((code?: string | number | null) => {
+    throw new Error(`exit:${code}`);
+  });
 }
 
 describe('getSupportedClients', () => {
@@ -57,6 +94,67 @@ describe('getClientConfig', () => {
   it('should return undefined for unknown client', () => {
     const config = getClientConfig('nonexistent' as never);
     expect(config).toBeUndefined();
+  });
+
+  it('should resolve platform-specific config paths', () => {
+    const home = os.homedir();
+    process.env.APPDATA = 'C:\\Users\\tester\\AppData\\Roaming';
+    process.env.XDG_CONFIG_HOME = '/tmp/xdg-config';
+
+    setPlatform('darwin');
+    expect(getClientConfig('claude-desktop')?.getConfigPath()).toBe(
+      path.join(home, 'Library', 'Application Support', 'Claude', 'claude_desktop_config.json')
+    );
+    expect(getClientConfig('cline')?.getConfigPath()).toContain(
+      path.join('Library', 'Application Support', 'Code')
+    );
+    expect(getClientConfig('trae')?.getConfigPath()).toContain(
+      path.join('Library', 'Application Support', 'Trae')
+    );
+    expect(getClientConfig('vscode')?.getConfigPath()).toBe(
+      path.join(process.cwd(), '.vscode', 'mcp.json')
+    );
+    expect(getClientConfig('cursor')?.getConfigPath()).toBe(path.join(home, '.cursor', 'mcp.json'));
+    expect(getClientConfig('windsurf')?.getConfigPath()).toBe(
+      path.join(home, '.windsurf', 'mcp.json')
+    );
+    expect(getClientConfig('qoder')?.getConfigPath()).toBe(path.join(home, '.qoder', 'mcp.json'));
+    expect(getClientConfig('opencode')?.getConfigPath()).toBe(
+      path.join(process.cwd(), 'opencode.json')
+    );
+
+    setPlatform('win32');
+    expect(getClientConfig('claude-desktop')?.getConfigPath()).toBe(
+      path.join('C:\\Users\\tester\\AppData\\Roaming', 'Claude', 'claude_desktop_config.json')
+    );
+    expect(getClientConfig('cline')?.getConfigPath()).toContain(
+      path.join('Code', 'User', 'globalStorage')
+    );
+    expect(getClientConfig('trae')?.getConfigPath()).toContain(
+      path.join('Trae', 'User', 'globalStorage')
+    );
+
+    setPlatform('linux');
+    expect(getClientConfig('claude-desktop')?.getConfigPath()).toBe(
+      path.join('/tmp/xdg-config', 'Claude', 'claude_desktop_config.json')
+    );
+    expect(getClientConfig('cline')?.getConfigPath()).toContain(
+      path.join('/tmp/xdg-config', 'Code', 'User', 'globalStorage')
+    );
+    expect(getClientConfig('trae')?.getConfigPath()).toContain(
+      path.join('/tmp/xdg-config', 'Trae', 'User', 'globalStorage')
+    );
+
+    delete process.env.XDG_CONFIG_HOME;
+    expect(getClientConfig('claude-desktop')?.getConfigPath()).toBe(
+      path.join(home, '.config', 'Claude', 'claude_desktop_config.json')
+    );
+
+    setPlatform('freebsd');
+    process.env.XDG_CONFIG_HOME = '/tmp/freebsd-xdg';
+    expect(getClientConfig('claude-desktop')?.getConfigPath()).toBe(
+      path.join(home, '.config', 'Claude', 'claude_desktop_config.json')
+    );
   });
 });
 
@@ -200,6 +298,23 @@ describe('installToClient', () => {
     expect(content.mcpServers.yuque).toBeDefined();
   });
 
+  it('should include custom base URL in standard client env', () => {
+    const configPath = path.join(tmpDir, 'base-url', 'mcp.json');
+    mockConfigPath('cursor', configPath);
+
+    installToClient({
+      token: 'base-token',
+      client: 'cursor',
+      baseURL: 'https://yuque.internal/api/v2',
+    });
+
+    const content = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+    expect(content.mcpServers.yuque.env).toEqual({
+      YUQUE_PERSONAL_TOKEN: 'base-token',
+      YUQUE_BASE_URL: 'https://yuque.internal/api/v2',
+    });
+  });
+
   it('should create parent directories recursively', () => {
     const configPath = path.join(tmpDir, 'deep', 'nested', 'dir', 'mcp.json');
     mockConfigPath('cursor', configPath);
@@ -305,6 +420,23 @@ describe('installToClient', () => {
     expect(content.mcpServers).toBeUndefined();
   });
 
+  it('should include custom base URL in opencode environment', () => {
+    const configPath = path.join(tmpDir, 'opencode-base-url', 'opencode.json');
+    mockConfigPath('opencode', configPath);
+
+    installToClient({
+      token: 'opencode-base-token',
+      client: 'opencode',
+      baseURL: 'https://yuque.internal/api/v2',
+    });
+
+    const content = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+    expect(content.mcp.yuque.environment).toEqual({
+      YUQUE_PERSONAL_TOKEN: 'opencode-base-token',
+      YUQUE_BASE_URL: 'https://yuque.internal/api/v2',
+    });
+  });
+
   it('should merge opencode config with existing settings', () => {
     const configPath = path.join(tmpDir, 'opencode-merge', 'opencode.json');
     fs.mkdirSync(path.dirname(configPath), { recursive: true });
@@ -312,7 +444,7 @@ describe('installToClient', () => {
       configPath,
       JSON.stringify(
         {
-          '$schema': 'https://opencode.ai/config.json',
+          $schema: 'https://opencode.ai/config.json',
           model: 'anthropic/claude-sonnet-4-5',
           mcp: {
             'other-server': {
@@ -379,5 +511,94 @@ describe('installToClient', () => {
     expect(content.servers['yuque'].env.YUQUE_PERSONAL_TOKEN).toBe('vsc-merge-tok');
     // No mcpServers key should exist
     expect(content.mcpServers).toBeUndefined();
+  });
+});
+
+describe('runInstall', () => {
+  it('should install from CLI arguments', () => {
+    const configPath = path.join(tmpDir, 'run-install', 'mcp.json');
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+    mockConfigPath('cursor', configPath);
+
+    runInstall([
+      '--token=token=with=equals',
+      '--client=cursor',
+      '--base-url=https://yuque.internal/api/v2',
+    ]);
+
+    const content = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+    expect(content.mcpServers.yuque.env).toEqual({
+      YUQUE_PERSONAL_TOKEN: 'token=with=equals',
+      YUQUE_BASE_URL: 'https://yuque.internal/api/v2',
+    });
+    expect(log).toHaveBeenCalledWith(expect.stringContaining('Successfully configured'));
+  });
+
+  it('should exit when token argument is missing', () => {
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+    mockExit();
+
+    expect(() => runInstall(['--client=cursor'])).toThrow('exit:1');
+    expect(error).toHaveBeenCalledWith('Error: --token=YOUR_TOKEN is required.');
+  });
+
+  it('should exit when client argument is missing', () => {
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+    mockExit();
+
+    expect(() => runInstall(['--token=tok'])).toThrow('exit:1');
+    expect(error).toHaveBeenCalledWith('Error: --client=CLIENT is required.');
+  });
+
+  it('should exit when token value is empty', () => {
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+    mockExit();
+
+    expect(() => runInstall(['--token=', '--client=cursor'])).toThrow('exit:1');
+    expect(error).toHaveBeenCalledWith('Error: Token value cannot be empty.');
+  });
+
+  it('should print thrown Error messages', () => {
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+    mockExit();
+
+    expect(() => runInstall(['--token=tok', '--client=unknown-client'])).toThrow('exit:1');
+    expect(error).toHaveBeenCalledWith(expect.stringContaining('Unknown client'));
+  });
+
+  it('should print fallback message for non-Error failures', () => {
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const clientConfig = getClientConfig('cursor');
+    if (!clientConfig) throw new Error('cursor config missing');
+    clientConfig.getConfigPath = () => {
+      throw 'non-error failure';
+    };
+    mockExit();
+
+    expect(() => runInstall(['--token=tok', '--client=cursor'])).toThrow('exit:1');
+    expect(error).toHaveBeenCalledWith('\n❌ An unexpected error occurred.\n');
+  });
+});
+
+describe('handleCliSubcommands', () => {
+  it('should handle install subcommand', () => {
+    const configPath = path.join(tmpDir, 'handle-install', 'mcp.json');
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    mockConfigPath('cursor', configPath);
+
+    const handled = handleCliSubcommands([
+      'node',
+      'cli.js',
+      'install',
+      '--token=tok',
+      '--client=cursor',
+    ]);
+
+    expect(handled).toBe(true);
+    expect(fs.existsSync(configPath)).toBe(true);
+  });
+
+  it('should ignore unknown subcommands', () => {
+    expect(handleCliSubcommands(['node', 'cli.js', 'unknown'])).toBe(false);
   });
 });

--- a/tests/cli-install.test.ts
+++ b/tests/cli-install.test.ts
@@ -19,15 +19,25 @@ const originalGetConfigPaths = new Map(
   getSupportedClients().map((client) => [client, getClientConfig(client)?.getConfigPath])
 );
 
+function restoreEnv(name: string, value: string | undefined) {
+  if (value === undefined) {
+    delete process.env[name];
+  } else {
+    process.env[name] = value;
+  }
+}
+
 beforeEach(() => {
   tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'yuque-mcp-test-'));
   vi.restoreAllMocks();
-  process.env.APPDATA = originalAppData;
-  process.env.XDG_CONFIG_HOME = originalXdgConfigHome;
+  restoreEnv('APPDATA', originalAppData);
+  restoreEnv('XDG_CONFIG_HOME', originalXdgConfigHome);
 });
 
 afterEach(() => {
   fs.rmSync(tmpDir, { recursive: true, force: true });
+  restoreEnv('APPDATA', originalAppData);
+  restoreEnv('XDG_CONFIG_HOME', originalXdgConfigHome);
   for (const [client, getConfigPath] of originalGetConfigPaths) {
     const clientConfig = getClientConfig(client);
     if (clientConfig && getConfigPath) {

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -19,6 +19,14 @@ const originalBaseURL = process.env.YUQUE_BASE_URL;
 const originalIsTTY = Object.getOwnPropertyDescriptor(process.stdin, 'isTTY');
 let cliImportRun = 0;
 
+function restoreEnv(name: string, value: string | undefined) {
+  if (value === undefined) {
+    delete process.env[name];
+  } else {
+    process.env[name] = value;
+  }
+}
+
 function setIsTTY(value: boolean) {
   Object.defineProperty(process.stdin, 'isTTY', {
     value,
@@ -63,8 +71,8 @@ describe('CLI entry', () => {
   afterEach(() => {
     vi.restoreAllMocks();
     process.argv = originalArgv;
-    process.env.YUQUE_PERSONAL_TOKEN = originalToken;
-    process.env.YUQUE_BASE_URL = originalBaseURL;
+    restoreEnv('YUQUE_PERSONAL_TOKEN', originalToken);
+    restoreEnv('YUQUE_BASE_URL', originalBaseURL);
     if (originalIsTTY) {
       Object.defineProperty(process.stdin, 'isTTY', originalIsTTY);
     }

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+const cliMocks = vi.hoisted(() => ({
+  handleCliSubcommands: vi.fn(),
+  runStdioServer: vi.fn(),
+}));
+
+vi.mock('../src/cli-install.js', () => ({
+  handleCliSubcommands: cliMocks.handleCliSubcommands,
+}));
+
+vi.mock('../src/server.js', () => ({
+  runStdioServer: cliMocks.runStdioServer,
+}));
+
+const originalArgv = process.argv;
+const originalToken = process.env.YUQUE_PERSONAL_TOKEN;
+const originalBaseURL = process.env.YUQUE_BASE_URL;
+const originalIsTTY = Object.getOwnPropertyDescriptor(process.stdin, 'isTTY');
+let cliImportRun = 0;
+
+function setIsTTY(value: boolean) {
+  Object.defineProperty(process.stdin, 'isTTY', {
+    value,
+    configurable: true,
+  });
+}
+
+async function importCli() {
+  const importers = [
+    () => import('../src/cli.js?case=0'),
+    () => import('../src/cli.js?case=1'),
+    () => import('../src/cli.js?case=2'),
+    () => import('../src/cli.js?case=3'),
+    () => import('../src/cli.js?case=4'),
+  ];
+  const importer = importers[cliImportRun++];
+  if (!importer) throw new Error('No CLI import slot left');
+  return importer();
+}
+
+function mockExit(throws = true) {
+  return vi.spyOn(process, 'exit').mockImplementation((code?: string | number | null) => {
+    if (throws) {
+      throw new Error(`exit:${code}`);
+    }
+    return undefined as never;
+  });
+}
+
+describe('CLI entry', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+    cliMocks.handleCliSubcommands.mockReturnValue(false);
+    cliMocks.runStdioServer.mockResolvedValue(undefined);
+    process.argv = ['node', 'cli.js'];
+    delete process.env.YUQUE_PERSONAL_TOKEN;
+    delete process.env.YUQUE_BASE_URL;
+    setIsTTY(false);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    process.argv = originalArgv;
+    process.env.YUQUE_PERSONAL_TOKEN = originalToken;
+    process.env.YUQUE_BASE_URL = originalBaseURL;
+    if (originalIsTTY) {
+      Object.defineProperty(process.stdin, 'isTTY', originalIsTTY);
+    }
+  });
+
+  it('should stop when an install/setup subcommand is handled', async () => {
+    cliMocks.handleCliSubcommands.mockReturnValue(true);
+    process.argv = ['node', 'cli.js', 'install'];
+
+    await importCli();
+
+    expect(cliMocks.handleCliSubcommands).toHaveBeenCalledWith(process.argv);
+    expect(cliMocks.runStdioServer).not.toHaveBeenCalled();
+  });
+
+  it('should exit when token is missing', async () => {
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+    mockExit();
+
+    await expect(importCli()).rejects.toThrow('exit:1');
+
+    expect(error).toHaveBeenCalledWith(
+      'Error: YUQUE_PERSONAL_TOKEN environment variable or --token argument is required'
+    );
+  });
+
+  it('should print terminal guidance when run directly in a TTY', async () => {
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+    process.env.YUQUE_PERSONAL_TOKEN = 'env-token';
+    setIsTTY(true);
+    mockExit();
+
+    await expect(importCli()).rejects.toThrow('exit:0');
+
+    expect(log.mock.calls[0]?.[0]).toContain('Yuque MCP Server');
+    expect(cliMocks.runStdioServer).not.toHaveBeenCalled();
+  });
+
+  it('should start stdio server with token and base URL arguments', async () => {
+    process.argv = [
+      'node',
+      'cli.js',
+      '--token=arg-token',
+      '--base-url=https://yuque.internal/api/v2',
+    ];
+
+    await importCli();
+
+    expect(cliMocks.runStdioServer).toHaveBeenCalledWith(
+      'arg-token',
+      'https://yuque.internal/api/v2'
+    );
+  });
+
+  it('should exit when stdio startup fails', async () => {
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+    process.env.YUQUE_PERSONAL_TOKEN = 'env-token';
+    cliMocks.runStdioServer.mockRejectedValue(new Error('stdio failed'));
+    mockExit(false);
+
+    await importCli();
+    await Promise.resolve();
+
+    expect(error).toHaveBeenCalledWith('Fatal error:', expect.any(Error));
+    expect(process.exit).toHaveBeenCalledWith(1);
+  });
+});

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+type HttpHandler = (
+  req: unknown,
+  res: { statusCode?: number; end: (body: string) => void }
+) => void;
+
+const indexMocks = vi.hoisted(() => ({
+  createMCPServer: vi.fn(),
+  connect: vi.fn(),
+  handleRequest: vi.fn(),
+  listen: vi.fn(),
+  httpHandler: undefined as HttpHandler | undefined,
+  sessionId: undefined as string | undefined,
+}));
+
+vi.mock('../src/server.js', () => ({
+  createServer: indexMocks.createMCPServer,
+}));
+
+vi.mock('@modelcontextprotocol/sdk/server/streamableHttp.js', () => ({
+  StreamableHTTPServerTransport: vi.fn(function (
+    this: { handleRequest: typeof indexMocks.handleRequest },
+    options: { sessionIdGenerator: () => string }
+  ) {
+    indexMocks.sessionId = options.sessionIdGenerator();
+    this.handleRequest = indexMocks.handleRequest;
+  }),
+}));
+
+vi.mock('node:http', () => ({
+  createServer: vi.fn((handler: HttpHandler) => {
+    indexMocks.httpHandler = handler;
+    return {
+      listen: indexMocks.listen,
+    };
+  }),
+}));
+
+vi.mock('node:crypto', () => ({
+  randomUUID: vi.fn(() => 'uuid-1'),
+}));
+
+const originalArgv = process.argv;
+const originalToken = process.env.YUQUE_PERSONAL_TOKEN;
+const originalBaseURL = process.env.YUQUE_BASE_URL;
+const originalPort = process.env.PORT;
+let indexImportRun = 0;
+
+async function importHttpEntry() {
+  const importers = [
+    () => import('../src/index.js?case=0'),
+    () => import('../src/index.js?case=1'),
+    () => import('../src/index.js?case=2'),
+    () => import('../src/index.js?case=3'),
+  ];
+  const importer = importers[indexImportRun++];
+  if (!importer) throw new Error('No HTTP entry import slot left');
+  return importer();
+}
+
+function mockExit(throws = true) {
+  return vi.spyOn(process, 'exit').mockImplementation((code?: string | number | null) => {
+    if (throws) {
+      throw new Error(`exit:${code}`);
+    }
+    return undefined as never;
+  });
+}
+
+describe('HTTP entry', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+    indexMocks.connect.mockResolvedValue(undefined);
+    indexMocks.handleRequest.mockResolvedValue(undefined);
+    indexMocks.listen.mockImplementation((_port: number, callback: () => void) => callback());
+    indexMocks.createMCPServer.mockReturnValue({
+      connect: indexMocks.connect,
+    });
+    indexMocks.httpHandler = undefined;
+    indexMocks.sessionId = undefined;
+    process.argv = ['node', 'index.js'];
+    delete process.env.YUQUE_PERSONAL_TOKEN;
+    delete process.env.YUQUE_BASE_URL;
+    delete process.env.PORT;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    process.argv = originalArgv;
+    process.env.YUQUE_PERSONAL_TOKEN = originalToken;
+    process.env.YUQUE_BASE_URL = originalBaseURL;
+    process.env.PORT = originalPort;
+  });
+
+  it('should exit when token is missing', async () => {
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+    mockExit();
+
+    await expect(importHttpEntry()).rejects.toThrow('exit:1');
+
+    expect(error).toHaveBeenCalledWith(
+      'Error: YUQUE_PERSONAL_TOKEN environment variable or --token argument is required'
+    );
+  });
+
+  it('should start HTTP server and handle request failures', async () => {
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+    process.argv = [
+      'node',
+      'index.js',
+      '--token=arg-token',
+      '--base-url=https://yuque.internal/api/v2',
+    ];
+    process.env.PORT = '4242';
+
+    await importHttpEntry();
+    await Promise.resolve();
+
+    expect(indexMocks.createMCPServer).toHaveBeenCalledWith(
+      'arg-token',
+      'https://yuque.internal/api/v2'
+    );
+    expect(indexMocks.sessionId).toBe('uuid-1');
+    expect(indexMocks.listen).toHaveBeenCalledWith(4242, expect.any(Function));
+    expect(log).toHaveBeenCalledWith('Yuque MCP Server running on http://localhost:4242');
+
+    indexMocks.handleRequest.mockRejectedValue(new Error('request failed'));
+    const res = {
+      statusCode: 200,
+      end: vi.fn(),
+    };
+    indexMocks.httpHandler?.({}, res);
+    await Promise.resolve();
+
+    expect(error).toHaveBeenCalledWith('Request handling error:', expect.any(Error));
+    expect(res.statusCode).toBe(500);
+    expect(res.end).toHaveBeenCalledWith('Internal Server Error');
+  });
+
+  it('should use environment token and default port', async () => {
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+    process.env.YUQUE_PERSONAL_TOKEN = 'env-token';
+    process.env.YUQUE_BASE_URL = 'https://env.example/api/v2';
+
+    await importHttpEntry();
+    await Promise.resolve();
+
+    expect(indexMocks.createMCPServer).toHaveBeenCalledWith(
+      'env-token',
+      'https://env.example/api/v2'
+    );
+    expect(indexMocks.listen).toHaveBeenCalledWith(3000, expect.any(Function));
+    expect(log).toHaveBeenCalledWith('Yuque MCP Server running on http://localhost:3000');
+  });
+
+  it('should exit when MCP server connection fails', async () => {
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+    process.env.YUQUE_PERSONAL_TOKEN = 'env-token';
+    indexMocks.connect.mockRejectedValue(new Error('connect failed'));
+    mockExit(false);
+
+    await importHttpEntry();
+    await Promise.resolve();
+
+    expect(error).toHaveBeenCalledWith('Failed to start server:', expect.any(Error));
+    expect(process.exit).toHaveBeenCalledWith(1);
+  });
+});

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -47,6 +47,14 @@ const originalBaseURL = process.env.YUQUE_BASE_URL;
 const originalPort = process.env.PORT;
 let indexImportRun = 0;
 
+function restoreEnv(name: string, value: string | undefined) {
+  if (value === undefined) {
+    delete process.env[name];
+  } else {
+    process.env[name] = value;
+  }
+}
+
 async function importHttpEntry() {
   const importers = [
     () => import('../src/index.js?case=0'),
@@ -89,9 +97,9 @@ describe('HTTP entry', () => {
   afterEach(() => {
     vi.restoreAllMocks();
     process.argv = originalArgv;
-    process.env.YUQUE_PERSONAL_TOKEN = originalToken;
-    process.env.YUQUE_BASE_URL = originalBaseURL;
-    process.env.PORT = originalPort;
+    restoreEnv('YUQUE_PERSONAL_TOKEN', originalToken);
+    restoreEnv('YUQUE_BASE_URL', originalBaseURL);
+    restoreEnv('PORT', originalPort);
   });
 
   it('should exit when token is missing', async () => {

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -1,11 +1,46 @@
 import { createRequire } from 'node:module';
-import { describe, it, expect } from 'vitest';
-import { createServer, MCP_SERVER_VERSION } from '../src/server.js';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import axios from 'axios';
+import { createServer, MCP_SERVER_VERSION, runStdioServer } from '../src/server.js';
+
+vi.mock('axios');
+
+const { transportStart } = vi.hoisted(() => ({
+  transportStart: vi.fn(),
+}));
+
+vi.mock('@modelcontextprotocol/sdk/server/stdio.js', () => ({
+  StdioServerTransport: class {
+    start = transportStart;
+    send = vi.fn();
+    close = vi.fn();
+  },
+}));
 
 const require = createRequire(import.meta.url);
 const packageJson = require('../package.json');
+const mockedAxios = vi.mocked(axios, true);
+
+function getRequestHandler<T>(server: unknown, method: string) {
+  return (
+    server as {
+      _requestHandlers: Map<string, (request: unknown, extra: unknown) => Promise<T>>;
+    }
+  )._requestHandlers.get(method);
+}
 
 describe('createServer', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockedAxios.create.mockReturnValue({
+      get: vi.fn(),
+      post: vi.fn(),
+      put: vi.fn(),
+      delete: vi.fn(),
+    } as never);
+    transportStart.mockResolvedValue(undefined);
+  });
+
   it('should create a server instance', () => {
     const server = createServer('test-token');
     expect(server).toBeDefined();
@@ -22,14 +57,10 @@ describe('createServer', () => {
 
   it('should register all 19 tools', async () => {
     const server = createServer('test-token');
-    const listToolsHandler = (
-      server as unknown as {
-        _requestHandlers: Map<
-          string,
-          (request: unknown, extra: unknown) => Promise<{ tools: Array<{ name: string }> }>
-        >;
-      }
-    )._requestHandlers.get('tools/list');
+    const listToolsHandler = getRequestHandler<{ tools: Array<{ name: string }> }>(
+      server,
+      'tools/list'
+    );
 
     const result = await listToolsHandler?.({ method: 'tools/list', params: {} }, {});
 
@@ -41,5 +72,121 @@ describe('createServer', () => {
         'yuque_update_resource',
       ])
     );
+  });
+
+  it('should call a registered tool through the MCP call handler', async () => {
+    const server = createServer('test-token');
+    const mockHttpClient = mockedAxios.create.mock.results[0].value as {
+      get: ReturnType<typeof vi.fn>;
+    };
+    mockHttpClient.get.mockResolvedValue({
+      data: {
+        data: {
+          id: 1,
+          login: 'tester',
+          name: 'Tester',
+          description: 'ok',
+          avatar_url: 'https://example.com/avatar.png',
+          books_count: 2,
+          followers_count: 3,
+        },
+      },
+    });
+
+    const callToolHandler = getRequestHandler<{ content: Array<{ text: string }> }>(
+      server,
+      'tools/call'
+    );
+    const result = await callToolHandler?.(
+      {
+        method: 'tools/call',
+        params: {
+          name: 'yuque_get_user',
+          arguments: {},
+        },
+      },
+      {}
+    );
+
+    expect(JSON.parse(result?.content[0].text ?? '{}')).toMatchObject({
+      id: 1,
+      login: 'tester',
+    });
+  });
+
+  it('should throw for an unknown tool name', async () => {
+    const server = createServer('test-token');
+    const callToolHandler = getRequestHandler(server, 'tools/call');
+
+    await expect(
+      callToolHandler?.(
+        {
+          method: 'tools/call',
+          params: {
+            name: 'yuque_unknown',
+            arguments: {},
+          },
+        },
+        {}
+      )
+    ).rejects.toThrow('Unknown tool: yuque_unknown');
+  });
+
+  it('should return an MCP error response for invalid tool arguments', async () => {
+    const server = createServer('test-token');
+    const callToolHandler = getRequestHandler<{
+      content: Array<{ text: string }>;
+      isError: boolean;
+    }>(server, 'tools/call');
+
+    const result = await callToolHandler?.(
+      {
+        method: 'tools/call',
+        params: {
+          name: 'yuque_get_book',
+          arguments: {},
+        },
+      },
+      {}
+    );
+
+    expect(result?.isError).toBe(true);
+    expect(result?.content[0].text).toContain('Tool execution failed');
+  });
+
+  it('should return an MCP error response when the tool handler fails', async () => {
+    const server = createServer('test-token');
+    const mockHttpClient = mockedAxios.create.mock.results[0].value as {
+      get: ReturnType<typeof vi.fn>;
+    };
+    mockHttpClient.get.mockRejectedValue(new Error('network down'));
+    const callToolHandler = getRequestHandler<{
+      content: Array<{ text: string }>;
+      isError: boolean;
+    }>(server, 'tools/call');
+
+    const result = await callToolHandler?.(
+      {
+        method: 'tools/call',
+        params: {
+          name: 'yuque_get_user',
+          arguments: {},
+        },
+      },
+      {}
+    );
+
+    expect(result?.isError).toBe(true);
+    expect(result?.content[0].text).toContain('network down');
+  });
+
+  it('should run the stdio server', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await runStdioServer('test-token', 'https://yuque.internal/api/v2');
+
+    expect(transportStart).toHaveBeenCalledTimes(1);
+    expect(consoleError).toHaveBeenCalledWith('Yuque MCP Server running on stdio');
+    consoleError.mockRestore();
   });
 });

--- a/tests/services/yuque-client.test.ts
+++ b/tests/services/yuque-client.test.ts
@@ -102,6 +102,16 @@ describe('YuqueClient', () => {
   });
 
   describe('repo operations', () => {
+    it('should list groups for a user', async () => {
+      const mockGroups = [{ id: 1, login: 'team', name: 'Team' }];
+      const mockClient = client['client'] as { get: ReturnType<typeof vi.fn> };
+      mockClient.get.mockResolvedValue({ data: { data: mockGroups } });
+
+      const result = await client.listGroups(123);
+      expect(result).toEqual(mockGroups);
+      expect(mockClient.get).toHaveBeenCalledWith('/users/123/groups');
+    });
+
     it('should list user repos', async () => {
       const mockRepos = [
         {
@@ -121,6 +131,16 @@ describe('YuqueClient', () => {
       const result = await client.listUserRepos('testuser');
       expect(result).toEqual(mockRepos);
       expect(mockClient.get).toHaveBeenCalledWith('/users/testuser/repos');
+    });
+
+    it('should list group repos', async () => {
+      const mockRepos = [{ id: 1, name: 'Group Repo' }];
+      const mockClient = client['client'] as { get: ReturnType<typeof vi.fn> };
+      mockClient.get.mockResolvedValue({ data: { data: mockRepos } });
+
+      const result = await client.listGroupRepos('team');
+      expect(result).toEqual(mockRepos);
+      expect(mockClient.get).toHaveBeenCalledWith('/groups/team/repos');
     });
 
     it('should get repo by ID', async () => {
@@ -169,6 +189,40 @@ describe('YuqueClient', () => {
         name: 'New Repo',
         slug: 'new-repo',
       });
+    });
+
+    it('should create group repo', async () => {
+      const mockRepo = { id: 2, name: 'Group Repo', slug: 'group-repo' };
+      const mockClient = client['client'] as { post: ReturnType<typeof vi.fn> };
+      mockClient.post.mockResolvedValue({ data: { data: mockRepo } });
+
+      const result = await client.createGroupRepo('team', {
+        name: 'Group Repo',
+        slug: 'group-repo',
+      });
+      expect(result).toEqual(mockRepo);
+      expect(mockClient.post).toHaveBeenCalledWith('/groups/team/repos', {
+        name: 'Group Repo',
+        slug: 'group-repo',
+      });
+    });
+
+    it('should update repo', async () => {
+      const mockRepo = { id: 1, name: 'Updated Repo' };
+      const mockClient = client['client'] as { put: ReturnType<typeof vi.fn> };
+      mockClient.put.mockResolvedValue({ data: { data: mockRepo } });
+
+      const result = await client.updateRepo('team/repo', { name: 'Updated Repo' });
+      expect(result).toEqual(mockRepo);
+      expect(mockClient.put).toHaveBeenCalledWith('/repos/team/repo', { name: 'Updated Repo' });
+    });
+
+    it('should delete repo', async () => {
+      const mockClient = client['client'] as { delete: ReturnType<typeof vi.fn> };
+      mockClient.delete.mockResolvedValue({});
+
+      await client.deleteRepo(1);
+      expect(mockClient.delete).toHaveBeenCalledWith('/repos/1');
     });
   });
 
@@ -397,6 +451,235 @@ describe('YuqueClient', () => {
 
       await client.deleteDoc(1, 1);
       expect(mockClient.delete).toHaveBeenCalledWith('/repos/1/docs/1');
+    });
+  });
+
+  describe('toc operations', () => {
+    it('should get toc', async () => {
+      const mockToc = [{ title: 'Intro', uuid: 'u1', doc_id: 1 }];
+      const mockClient = client['client'] as { get: ReturnType<typeof vi.fn> };
+      mockClient.get.mockResolvedValue({ data: { data: mockToc } });
+
+      const result = await client.getToc('team/repo');
+      expect(result).toEqual(mockToc);
+      expect(mockClient.get).toHaveBeenCalledWith('/repos/team/repo/toc');
+    });
+
+    it('should update toc', async () => {
+      const mockToc = [{ title: 'Intro', uuid: 'u1', doc_id: 1 }];
+      const mockClient = client['client'] as { put: ReturnType<typeof vi.fn> };
+      mockClient.put.mockResolvedValue({ data: { data: mockToc } });
+
+      const result = await client.updateToc(1, '{"action":"appendNode"}');
+      expect(result).toEqual(mockToc);
+      expect(mockClient.put).toHaveBeenCalledWith('/repos/1/toc', '{"action":"appendNode"}');
+    });
+  });
+
+  describe('doc version operations', () => {
+    it('should list doc versions', async () => {
+      const mockVersions = [{ id: 1, doc_id: 2, title: 'v1' }];
+      const mockClient = client['client'] as { get: ReturnType<typeof vi.fn> };
+      mockClient.get.mockResolvedValue({ data: { data: mockVersions } });
+
+      const result = await client.listDocVersions(2);
+      expect(result).toEqual(mockVersions);
+      expect(mockClient.get).toHaveBeenCalledWith('/doc_versions', {
+        params: { doc_id: 2 },
+      });
+    });
+
+    it('should get a doc version', async () => {
+      const mockVersion = { id: 9, doc_id: 2, title: 'v9' };
+      const mockClient = client['client'] as { get: ReturnType<typeof vi.fn> };
+      mockClient.get.mockResolvedValue({ data: { data: mockVersion } });
+
+      const result = await client.getDocVersion(9);
+      expect(result).toEqual(mockVersion);
+      expect(mockClient.get).toHaveBeenCalledWith('/doc_versions/9');
+    });
+  });
+
+  describe('group member and statistics operations', () => {
+    it('should list group members', async () => {
+      const mockMembers = [{ id: 1, login: 'member' }];
+      const mockClient = client['client'] as { get: ReturnType<typeof vi.fn> };
+      mockClient.get.mockResolvedValue({ data: { data: mockMembers } });
+
+      const result = await client.listGroupMembers('team');
+      expect(result).toEqual(mockMembers);
+      expect(mockClient.get).toHaveBeenCalledWith('/groups/team/users');
+    });
+
+    it('should update group member role', async () => {
+      const mockMember = { id: 1, role: 2 };
+      const mockClient = client['client'] as { put: ReturnType<typeof vi.fn> };
+      mockClient.put.mockResolvedValue({ data: { data: mockMember } });
+
+      const result = await client.updateGroupMember('team', 1, { role: 2 });
+      expect(result).toEqual(mockMember);
+      expect(mockClient.put).toHaveBeenCalledWith('/groups/team/users/1', { role: 2 });
+    });
+
+    it('should remove group member', async () => {
+      const mockClient = client['client'] as { delete: ReturnType<typeof vi.fn> };
+      mockClient.delete.mockResolvedValue({});
+
+      await client.removeGroupMember('team', 1);
+      expect(mockClient.delete).toHaveBeenCalledWith('/groups/team/users/1');
+    });
+
+    it('should get group statistics', async () => {
+      const mockStats = { books_count: 3, docs_count: 10 };
+      const mockClient = client['client'] as { get: ReturnType<typeof vi.fn> };
+      mockClient.get.mockResolvedValue({ data: { data: mockStats } });
+
+      const result = await client.getGroupStats('team');
+      expect(result).toEqual(mockStats);
+      expect(mockClient.get).toHaveBeenCalledWith('/groups/team/statistics');
+    });
+
+    it.each([
+      ['member', () => client.getGroupMemberStats('team'), '/groups/team/statistics/members'],
+      ['book', () => client.getGroupBookStats('team'), '/groups/team/statistics/books'],
+      ['doc', () => client.getGroupDocStats('team'), '/groups/team/statistics/docs'],
+    ])('should get %s statistics', async (_label, call, path) => {
+      const mockStats = { total: 1 };
+      const mockClient = client['client'] as { get: ReturnType<typeof vi.fn> };
+      mockClient.get.mockResolvedValue({ data: { data: mockStats } });
+
+      const result = await call();
+      expect(result).toEqual(mockStats);
+      expect(mockClient.get).toHaveBeenCalledWith(path);
+    });
+  });
+
+  describe('hello and note operations', () => {
+    it('should call hello', async () => {
+      const mockMessage = { message: 'ok' };
+      const mockClient = client['client'] as { get: ReturnType<typeof vi.fn> };
+      mockClient.get.mockResolvedValue({ data: { data: mockMessage } });
+
+      const result = await client.hello();
+      expect(result).toEqual(mockMessage);
+      expect(mockClient.get).toHaveBeenCalledWith('/hello');
+    });
+
+    it('should list notes with params', async () => {
+      const mockNotes = { notes: [], pin_notes: [], has_more: false };
+      const mockClient = client['client'] as { get: ReturnType<typeof vi.fn> };
+      mockClient.get.mockResolvedValue({ data: { data: mockNotes } });
+
+      const result = await client.listNotes(0, 2, 20);
+      expect(result).toEqual(mockNotes);
+      expect(mockClient.get).toHaveBeenCalledWith('/notes', {
+        params: { status: 0, page: 2, limit: 20 },
+      });
+    });
+
+    it('should get note', async () => {
+      const mockNote = { id: 1, content: { source: 'note' } };
+      const mockClient = client['client'] as { get: ReturnType<typeof vi.fn> };
+      mockClient.get.mockResolvedValue({ data: { data: mockNote } });
+
+      const result = await client.getNote(1);
+      expect(result).toEqual(mockNote);
+      expect(mockClient.get).toHaveBeenCalledWith('/notes/1');
+    });
+
+    it('should create note', async () => {
+      const mockNote = { id: 1, slug: 'note' };
+      const mockClient = client['client'] as { post: ReturnType<typeof vi.fn> };
+      mockClient.post.mockResolvedValue({ data: { data: mockNote } });
+
+      const result = await client.createNote({ body: 'hello' });
+      expect(result).toEqual(mockNote);
+      expect(mockClient.post).toHaveBeenCalledWith('/notes', { body: 'hello' });
+    });
+
+    it('should update note', async () => {
+      const mockNote = { id: 1, content: { source: 'updated' } };
+      const mockClient = client['client'] as { put: ReturnType<typeof vi.fn> };
+      mockClient.put.mockResolvedValue({ data: { data: { data: mockNote } } });
+
+      const result = await client.updateNote(1, {
+        source: 'updated',
+        html: '<p>updated</p>',
+        abstract: 'updated',
+      });
+      expect(result).toEqual(mockNote);
+      expect(mockClient.put).toHaveBeenCalledWith('/notes/1', {
+        source: 'updated',
+        html: '<p>updated</p>',
+        abstract: 'updated',
+      });
+    });
+
+    it('should delete note by moving it to trash', async () => {
+      const mockClient = client['client'] as {
+        get: ReturnType<typeof vi.fn>;
+        put: ReturnType<typeof vi.fn>;
+      };
+      mockClient.get.mockResolvedValue({
+        data: {
+          data: {
+            id: 1,
+            content: {
+              source: 'source',
+              html: '<p>source</p>',
+              abstract: 'source',
+            },
+          },
+        },
+      });
+      mockClient.put.mockResolvedValue({ data: { data: { data: { id: 1 } } } });
+
+      await client.deleteNote(1);
+      expect(mockClient.put).toHaveBeenCalledWith('/notes/1', {
+        source: 'source',
+        html: '<p>source</p>',
+        abstract: 'source',
+        status: 9,
+      });
+    });
+
+    it('should restore note from trash', async () => {
+      const mockClient = client['client'] as {
+        get: ReturnType<typeof vi.fn>;
+        put: ReturnType<typeof vi.fn>;
+      };
+      mockClient.get.mockResolvedValue({
+        data: {
+          data: {
+            id: 1,
+            content: {},
+          },
+        },
+      });
+      mockClient.put.mockResolvedValue({ data: { data: { data: { id: 1 } } } });
+
+      await client.restoreNote(1);
+      expect(mockClient.put).toHaveBeenCalledWith('/notes/1', {
+        source: '',
+        html: '',
+        abstract: '',
+        status: 0,
+      });
+    });
+  });
+
+  describe('error handling', () => {
+    it('should normalize rejected API errors', async () => {
+      const mockClient = client['client'] as { get: ReturnType<typeof vi.fn> };
+      mockClient.get.mockRejectedValue({
+        response: {
+          status: 404,
+          data: { message: 'Missing' },
+        },
+      });
+
+      await expect(client.getUser()).rejects.toThrow('Missing');
+      await expect(client.getUser()).rejects.toThrow('Not found');
     });
   });
 });

--- a/tests/tools/book.test.ts
+++ b/tests/tools/book.test.ts
@@ -11,13 +11,23 @@ const mockClient = {
 
 beforeEach(() => vi.clearAllMocks());
 
-const mockRepo = { id: 1, slug: 'book', name: 'Book', namespace: 'user/book', description: '', public: 1, items_count: 5 };
+const mockRepo = {
+  id: 1,
+  slug: 'book',
+  name: 'Book',
+  namespace: 'user/book',
+  description: '',
+  public: 1,
+  items_count: 5,
+};
 
 describe('bookTools', () => {
   describe('yuque_list_books', () => {
     it('should list user books', async () => {
       (mockClient.listUserRepos as ReturnType<typeof vi.fn>).mockResolvedValue([mockRepo]);
-      const result = await bookTools.yuque_list_books.handler(mockClient, { login: 'user' } as never);
+      const result = await bookTools.yuque_list_books.handler(mockClient, {
+        login: 'user',
+      } as never);
       const parsed = JSON.parse(result.content[0].text);
       expect(parsed).toHaveLength(1);
       expect(mockClient.listUserRepos).toHaveBeenCalledWith('user');
@@ -42,17 +52,28 @@ describe('bookTools', () => {
     it('should create user book', async () => {
       (mockClient.createUserRepo as ReturnType<typeof vi.fn>).mockResolvedValue(mockRepo);
       await bookTools.yuque_create_book.handler(mockClient, {
-        login: 'user', name: 'Book', slug: 'book',
+        login: 'user',
+        name: 'Book',
+        slug: 'book',
       } as never);
-      expect(mockClient.createUserRepo).toHaveBeenCalledWith('user', expect.objectContaining({ name: 'Book', slug: 'book' }));
+      expect(mockClient.createUserRepo).toHaveBeenCalledWith(
+        'user',
+        expect.objectContaining({ name: 'Book', slug: 'book' })
+      );
     });
   });
 
   describe('yuque_update_book', () => {
     it('should update book', async () => {
       (mockClient.updateRepo as ReturnType<typeof vi.fn>).mockResolvedValue(mockRepo);
-      await bookTools.yuque_update_book.handler(mockClient, { repo_id: 1, name: 'Updated' } as never);
-      expect(mockClient.updateRepo).toHaveBeenCalledWith(1, expect.objectContaining({ name: 'Updated' }));
+      await bookTools.yuque_update_book.handler(mockClient, {
+        repo_id: 1,
+        name: 'Updated',
+      } as never);
+      expect(mockClient.updateRepo).toHaveBeenCalledWith(
+        1,
+        expect.objectContaining({ name: 'Updated' })
+      );
     });
   });
 });

--- a/tests/tools/doc.test.ts
+++ b/tests/tools/doc.test.ts
@@ -19,7 +19,15 @@ describe('docTools', () => {
   describe('yuque_list_docs', () => {
     it('should list docs for a repo', async () => {
       (mockClient.listDocs as ReturnType<typeof vi.fn>).mockResolvedValue([
-        { id: 1, slug: 'doc1', title: 'Doc 1', format: 'markdown', created_at: '2024-01-01', updated_at: '2024-01-02', word_count: 100 },
+        {
+          id: 1,
+          slug: 'doc1',
+          title: 'Doc 1',
+          format: 'markdown',
+          created_at: '2024-01-01',
+          updated_at: '2024-01-02',
+          word_count: 100,
+        },
       ]);
       const result = await docTools.yuque_list_docs.handler(mockClient, { repo_id: 1 } as never);
       const parsed = JSON.parse(result.content[0].text);
@@ -38,13 +46,28 @@ describe('docTools', () => {
   describe('yuque_get_doc', () => {
     it('should get doc with YMD-compatible content by default', async () => {
       (mockClient.getDoc as ReturnType<typeof vi.fn>).mockResolvedValue({
-        id: 1, slug: 'doc1', title: 'Doc 1', body: '# Hello', body_html: '<h1>Hello</h1>',
-        format: 'markdown', created_at: '2024-01-01', updated_at: '2024-01-02', word_count: 100,
+        id: 1,
+        slug: 'doc1',
+        title: 'Doc 1',
+        body: '# Hello',
+        body_html: '<h1>Hello</h1>',
+        format: 'markdown',
+        created_at: '2024-01-01',
+        updated_at: '2024-01-02',
+        word_count: 100,
       });
       (mockClient.getYmdDoc as ReturnType<typeof vi.fn>).mockResolvedValue({
-        doc_id: 1, title: 'Doc 1', url: '/user/repo/doc1', yfm: '# Hello from YMD', updated_at: '2024-01-03',
+        doc_id: 1,
+        title: 'Doc 1',
+        url: '/user/repo/doc1',
+        yfm: '# Hello from YMD',
+        updated_at: '2024-01-03',
       });
-      const result = await docTools.yuque_get_doc.handler(mockClient, { repo_id: 1, doc_id: 1, include_lake: false } as never);
+      const result = await docTools.yuque_get_doc.handler(mockClient, {
+        repo_id: 1,
+        doc_id: 1,
+        include_lake: false,
+      } as never);
       const parsed = JSON.parse(result.content[0].text);
       expect(parsed).toHaveProperty('body', '# Hello from YMD');
       expect(parsed).toHaveProperty('format', 'markdown');
@@ -56,14 +79,29 @@ describe('docTools', () => {
 
     it('should include body_lake when include_lake is true', async () => {
       (mockClient.getDoc as ReturnType<typeof vi.fn>).mockResolvedValue({
-        id: 1, slug: 'doc1', title: 'Doc 1', body: '# Hello', body_html: '<h1>Hello</h1>',
+        id: 1,
+        slug: 'doc1',
+        title: 'Doc 1',
+        body: '# Hello',
+        body_html: '<h1>Hello</h1>',
         body_lake: '<!doctype lake><p>Hello</p>',
-        format: 'markdown', created_at: '2024-01-01', updated_at: '2024-01-02', word_count: 100,
+        format: 'markdown',
+        created_at: '2024-01-01',
+        updated_at: '2024-01-02',
+        word_count: 100,
       });
       (mockClient.getYmdDoc as ReturnType<typeof vi.fn>).mockResolvedValue({
-        doc_id: 1, title: 'Doc 1', url: '/user/repo/doc1', yfm: '# Hello from YMD', updated_at: '2024-01-03',
+        doc_id: 1,
+        title: 'Doc 1',
+        url: '/user/repo/doc1',
+        yfm: '# Hello from YMD',
+        updated_at: '2024-01-03',
       });
-      const result = await docTools.yuque_get_doc.handler(mockClient, { repo_id: 1, doc_id: 1, include_lake: true } as never);
+      const result = await docTools.yuque_get_doc.handler(mockClient, {
+        repo_id: 1,
+        doc_id: 1,
+        include_lake: true,
+      } as never);
       const parsed = JSON.parse(result.content[0].text);
       expect(parsed).toHaveProperty('body', '# Hello from YMD');
       expect(parsed).toHaveProperty('body_lake', '<!doctype lake><p>Hello</p>');
@@ -71,12 +109,22 @@ describe('docTools', () => {
 
     it('should use legacy doc content when read format is lake', async () => {
       (mockClient.getDoc as ReturnType<typeof vi.fn>).mockResolvedValue({
-        id: 1, slug: 'doc1', title: 'Doc 1', body: '# Hello', body_html: '<h1>Hello</h1>',
-        format: 'lake', created_at: '2024-01-01', updated_at: '2024-01-02', word_count: 100,
+        id: 1,
+        slug: 'doc1',
+        title: 'Doc 1',
+        body: '# Hello',
+        body_html: '<h1>Hello</h1>',
+        format: 'lake',
+        created_at: '2024-01-01',
+        updated_at: '2024-01-02',
+        word_count: 100,
       });
 
       const result = await docTools.yuque_get_doc.handler(mockClient, {
-        repo_id: 1, doc_id: 1, format: 'lake', include_lake: false,
+        repo_id: 1,
+        doc_id: 1,
+        format: 'lake',
+        include_lake: false,
       } as never);
 
       const parsed = JSON.parse(result.content[0].text);
@@ -89,25 +137,44 @@ describe('docTools', () => {
   describe('yuque_create_doc', () => {
     it('should create doc with title and body', async () => {
       (mockClient.createDoc as ReturnType<typeof vi.fn>).mockResolvedValue({
-        id: 2, slug: 'new-doc', title: 'New Doc', body: 'Content',
-        format: 'markdown', created_at: '2024-01-01', updated_at: '2024-01-01', word_count: 1,
+        id: 2,
+        slug: 'new-doc',
+        title: 'New Doc',
+        body: 'Content',
+        format: 'markdown',
+        created_at: '2024-01-01',
+        updated_at: '2024-01-01',
+        word_count: 1,
       });
       const result = await docTools.yuque_create_doc.handler(mockClient, {
-        repo_id: 1, title: 'New Doc', body: 'Content',
+        repo_id: 1,
+        title: 'New Doc',
+        body: 'Content',
       } as never);
       const parsed = JSON.parse(result.content[0].text);
       expect(parsed).toHaveProperty('title', 'New Doc');
-      expect(mockClient.createDoc).toHaveBeenCalledWith(1, expect.objectContaining({ title: 'New Doc', body: 'Content' }));
+      expect(mockClient.createDoc).toHaveBeenCalledWith(
+        1,
+        expect.objectContaining({ title: 'New Doc', body: 'Content' })
+      );
     });
 
     it('should auto-append created doc to TOC', async () => {
       (mockClient.createDoc as ReturnType<typeof vi.fn>).mockResolvedValue({
-        id: 2, slug: 'new-doc', title: 'New Doc', body: 'Content',
-        format: 'markdown', created_at: '2024-01-01', updated_at: '2024-01-01', word_count: 1,
+        id: 2,
+        slug: 'new-doc',
+        title: 'New Doc',
+        body: 'Content',
+        format: 'markdown',
+        created_at: '2024-01-01',
+        updated_at: '2024-01-01',
+        word_count: 1,
       });
       (mockClient.updateToc as ReturnType<typeof vi.fn>).mockResolvedValue([]);
       const result = await docTools.yuque_create_doc.handler(mockClient, {
-        repo_id: 1, title: 'New Doc', body: 'Content',
+        repo_id: 1,
+        title: 'New Doc',
+        body: 'Content',
       } as never);
       expect(mockClient.updateToc).toHaveBeenCalledWith(1, expect.stringContaining('"appendNode"'));
       expect(result.content).toHaveLength(1); // no warning
@@ -115,12 +182,19 @@ describe('docTools', () => {
 
     it('should return warning when TOC append fails', async () => {
       (mockClient.createDoc as ReturnType<typeof vi.fn>).mockResolvedValue({
-        id: 3, slug: 'doc3', title: 'Doc 3', body: '',
-        format: 'markdown', created_at: '2024-01-01', updated_at: '2024-01-01', word_count: 0,
+        id: 3,
+        slug: 'doc3',
+        title: 'Doc 3',
+        body: '',
+        format: 'markdown',
+        created_at: '2024-01-01',
+        updated_at: '2024-01-01',
+        word_count: 0,
       });
       (mockClient.updateToc as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('TOC error'));
       const result = await docTools.yuque_create_doc.handler(mockClient, {
-        repo_id: 1, title: 'Doc 3',
+        repo_id: 1,
+        title: 'Doc 3',
       } as never);
       expect(result.content).toHaveLength(2); // doc + warning
       expect(result.content[1].text).toContain('failed to auto-append to TOC');
@@ -130,15 +204,27 @@ describe('docTools', () => {
   describe('yuque_update_doc', () => {
     it('should update doc metadata without YMD body update', async () => {
       (mockClient.updateDoc as ReturnType<typeof vi.fn>).mockResolvedValue({
-        id: 1, slug: 'doc1', title: 'Updated', body: 'New content',
-        format: 'markdown', created_at: '2024-01-01', updated_at: '2024-01-02', word_count: 2,
+        id: 1,
+        slug: 'doc1',
+        title: 'Updated',
+        body: 'New content',
+        format: 'markdown',
+        created_at: '2024-01-01',
+        updated_at: '2024-01-02',
+        word_count: 2,
       });
       const result = await docTools.yuque_update_doc.handler(mockClient, {
-        repo_id: 1, doc_id: 1, title: 'Updated',
+        repo_id: 1,
+        doc_id: 1,
+        title: 'Updated',
       } as never);
       const parsed = JSON.parse(result.content[0].text);
       expect(parsed).toHaveProperty('title', 'Updated');
-      expect(mockClient.updateDoc).toHaveBeenCalledWith(1, 1, expect.objectContaining({ title: 'Updated' }));
+      expect(mockClient.updateDoc).toHaveBeenCalledWith(
+        1,
+        1,
+        expect.objectContaining({ title: 'Updated' })
+      );
       expect(mockClient.updateYmdDoc).not.toHaveBeenCalled();
     });
 
@@ -146,18 +232,34 @@ describe('docTools', () => {
       'should update markdown body through YMD flow when format is %s',
       async (format) => {
         (mockClient.getDoc as ReturnType<typeof vi.fn>).mockResolvedValue({
-          id: 1, slug: 'doc1', title: 'Doc 1', body: 'Old content',
-          format: 'markdown', created_at: '2024-01-01', updated_at: '2024-01-02', word_count: 2,
+          id: 1,
+          slug: 'doc1',
+          title: 'Doc 1',
+          body: 'Old content',
+          format: 'markdown',
+          created_at: '2024-01-01',
+          updated_at: '2024-01-02',
+          word_count: 2,
         });
         (mockClient.updateYmdDoc as ReturnType<typeof vi.fn>).mockResolvedValue({
-          doc_id: 1, title: 'Doc 1', url: '/user/repo/doc1', updated_at: '2024-01-03',
+          doc_id: 1,
+          title: 'Doc 1',
+          url: '/user/repo/doc1',
+          updated_at: '2024-01-03',
         });
         (mockClient.getYmdDoc as ReturnType<typeof vi.fn>).mockResolvedValue({
-          doc_id: 1, title: 'Doc 1', url: '/user/repo/doc1', yfm: '# Updated YMD', updated_at: '2024-01-03',
+          doc_id: 1,
+          title: 'Doc 1',
+          url: '/user/repo/doc1',
+          yfm: '# Updated YMD',
+          updated_at: '2024-01-03',
         });
 
         const result = await docTools.yuque_update_doc.handler(mockClient, {
-          repo_id: 1, doc_id: 1, body: '# Updated YMD', format,
+          repo_id: 1,
+          doc_id: 1,
+          body: '# Updated YMD',
+          format,
         } as never);
 
         const parsed = JSON.parse(result.content[0].text);
@@ -172,47 +274,86 @@ describe('docTools', () => {
 
     it('should update metadata and markdown body through mixed legacy/YMD flow', async () => {
       (mockClient.getDoc as ReturnType<typeof vi.fn>).mockResolvedValue({
-        id: 1, slug: 'doc1', title: 'Doc 1', body: 'Old content',
-        format: 'markdown', created_at: '2024-01-01', updated_at: '2024-01-02', word_count: 2,
+        id: 1,
+        slug: 'doc1',
+        title: 'Doc 1',
+        body: 'Old content',
+        format: 'markdown',
+        created_at: '2024-01-01',
+        updated_at: '2024-01-02',
+        word_count: 2,
       });
       (mockClient.updateDoc as ReturnType<typeof vi.fn>).mockResolvedValue({
-        id: 1, slug: 'doc1', title: 'Updated', body: 'Old content',
-        format: 'markdown', created_at: '2024-01-01', updated_at: '2024-01-03', word_count: 2,
+        id: 1,
+        slug: 'doc1',
+        title: 'Updated',
+        body: 'Old content',
+        format: 'markdown',
+        created_at: '2024-01-01',
+        updated_at: '2024-01-03',
+        word_count: 2,
       });
       (mockClient.updateYmdDoc as ReturnType<typeof vi.fn>).mockResolvedValue({
-        doc_id: 1, title: 'Updated', url: '/user/repo/doc1', updated_at: '2024-01-04',
+        doc_id: 1,
+        title: 'Updated',
+        url: '/user/repo/doc1',
+        updated_at: '2024-01-04',
       });
       (mockClient.getYmdDoc as ReturnType<typeof vi.fn>).mockResolvedValue({
-        doc_id: 1, title: 'Updated', url: '/user/repo/doc1', yfm: '# Updated YMD', updated_at: '2024-01-04',
+        doc_id: 1,
+        title: 'Updated',
+        url: '/user/repo/doc1',
+        yfm: '# Updated YMD',
+        updated_at: '2024-01-04',
       });
 
       const result = await docTools.yuque_update_doc.handler(mockClient, {
-        repo_id: 1, doc_id: 1, title: 'Updated', body: '# Updated YMD',
+        repo_id: 1,
+        doc_id: 1,
+        title: 'Updated',
+        body: '# Updated YMD',
       } as never);
 
       const parsed = JSON.parse(result.content[0].text);
       expect(parsed).toHaveProperty('title', 'Updated');
       expect(parsed).toHaveProperty('body', '# Updated YMD');
-      expect(mockClient.updateDoc).toHaveBeenCalledWith(1, 1, expect.objectContaining({ title: 'Updated' }));
+      expect(mockClient.updateDoc).toHaveBeenCalledWith(
+        1,
+        1,
+        expect.objectContaining({ title: 'Updated' })
+      );
       expect(mockClient.updateYmdDoc).toHaveBeenCalledWith(1, '# Updated YMD');
     });
 
     it('should use legacy doc update when body format is lake', async () => {
       (mockClient.updateDoc as ReturnType<typeof vi.fn>).mockResolvedValue({
-        id: 1, slug: 'doc1', title: 'Updated', body: '<!doctype lake><p>Updated</p>',
-        format: 'lake', created_at: '2024-01-01', updated_at: '2024-01-02', word_count: 2,
+        id: 1,
+        slug: 'doc1',
+        title: 'Updated',
+        body: '<!doctype lake><p>Updated</p>',
+        format: 'lake',
+        created_at: '2024-01-01',
+        updated_at: '2024-01-02',
+        word_count: 2,
       });
 
       const result = await docTools.yuque_update_doc.handler(mockClient, {
-        repo_id: 1, doc_id: 1, body: '<!doctype lake><p>Updated</p>', format: 'lake',
+        repo_id: 1,
+        doc_id: 1,
+        body: '<!doctype lake><p>Updated</p>',
+        format: 'lake',
       } as never);
 
       const parsed = JSON.parse(result.content[0].text);
       expect(parsed).toHaveProperty('format', 'lake');
-      expect(mockClient.updateDoc).toHaveBeenCalledWith(1, 1, expect.objectContaining({
-        body: '<!doctype lake><p>Updated</p>',
-        format: 'lake',
-      }));
+      expect(mockClient.updateDoc).toHaveBeenCalledWith(
+        1,
+        1,
+        expect.objectContaining({
+          body: '<!doctype lake><p>Updated</p>',
+          format: 'lake',
+        })
+      );
       expect(mockClient.updateYmdDoc).not.toHaveBeenCalled();
       expect(mockClient.getYmdDoc).not.toHaveBeenCalled();
     });

--- a/tests/tools/note.test.ts
+++ b/tests/tools/note.test.ts
@@ -12,6 +12,104 @@ const mockClient = {
 beforeEach(() => vi.clearAllMocks());
 
 describe('noteTools', () => {
+  describe('yuque_list_notes', () => {
+    it('should list pinned and regular notes with summaries', async () => {
+      (mockClient.listNotes as ReturnType<typeof vi.fn>).mockResolvedValue({
+        has_more: true,
+        pin_notes: [
+          {
+            id: 1,
+            slug: 'pinned',
+            content: { abstract: '<p>Pinned <strong>note</strong></p>' },
+            word_count: 3,
+            tags: ['pin'],
+            created_at: '2024-01-01',
+            updated_at: '2024-01-02',
+            pinned_at: '2024-01-03',
+            status: 0,
+          },
+        ],
+        notes: [
+          {
+            id: 2,
+            slug: 'regular',
+            content: { abstract: 'Regular note' },
+            word_count: 2,
+            tags: [],
+            created_at: '2024-01-04',
+            updated_at: '2024-01-05',
+            pinned_at: null,
+            status: 0,
+          },
+        ],
+      });
+
+      const result = await noteTools.yuque_list_notes.handler(mockClient, {
+        status: 0,
+        page: 2,
+        limit: 10,
+      });
+      const parsed = JSON.parse(result.content[0].text);
+
+      expect(parsed).toMatchObject({
+        total: 2,
+        pinned: 1,
+        has_more: true,
+      });
+      expect(parsed.notes[0]).toMatchObject({
+        id: 1,
+        slug: 'pinned',
+        content_preview: 'Pinned note',
+        is_pinned: true,
+      });
+      expect(parsed.notes[1]).toMatchObject({
+        id: 2,
+        slug: 'regular',
+        is_pinned: false,
+      });
+      expect(mockClient.listNotes).toHaveBeenCalledWith(0, 2, 10);
+    });
+  });
+
+  describe('yuque_get_note', () => {
+    it('should return full note content', async () => {
+      (mockClient.getNote as ReturnType<typeof vi.fn>).mockResolvedValue({
+        id: 3,
+        slug: 'full-note',
+        content: {
+          source: 'Plain text',
+          abstract: 'Fallback abstract',
+          html: '<p>Plain text</p>',
+        },
+        word_count: 2,
+        tags: ['daily'],
+        created_at: '2024-02-01',
+        updated_at: '2024-02-02',
+        published_at: '2024-02-03',
+        pinned_at: '2024-02-04',
+        likes_count: 4,
+        comments_count: 5,
+        status: 0,
+      });
+
+      const result = await noteTools.yuque_get_note.handler(mockClient, { note_id: 3 });
+      const parsed = JSON.parse(result.content[0].text);
+
+      expect(parsed).toMatchObject({
+        id: 3,
+        slug: 'full-note',
+        content: {
+          text: 'Plain text',
+          html: '<p>Plain text</p>',
+        },
+        is_pinned: true,
+        likes_count: 4,
+        comments_count: 5,
+      });
+      expect(mockClient.getNote).toHaveBeenCalledWith(3);
+    });
+  });
+
   describe('yuque_create_note', () => {
     it('should return id, slug, and note_url in the response', async () => {
       (mockClient.createNote as ReturnType<typeof vi.fn>).mockResolvedValue({
@@ -36,6 +134,45 @@ describe('noteTools', () => {
       });
       await noteTools.yuque_create_note.handler(mockClient, { body: 'Test content' });
       expect(mockClient.createNote).toHaveBeenCalledWith({ body: 'Test content' });
+    });
+  });
+
+  describe('yuque_update_note', () => {
+    it('should update source, html, and abstract from body', async () => {
+      (mockClient.updateNote as ReturnType<typeof vi.fn>).mockResolvedValue({
+        id: 4,
+        slug: 'updated',
+        content: {
+          source: 'Updated note',
+          html: '<p>Updated note</p>',
+        },
+        word_count: 2,
+        tags: [],
+        created_at: '2024-03-01',
+        updated_at: '2024-03-02',
+        published_at: null,
+        pinned_at: null,
+        likes_count: 0,
+        comments_count: 0,
+        status: 0,
+      });
+
+      const result = await noteTools.yuque_update_note.handler(mockClient, {
+        note_id: 4,
+        body: 'Updated note',
+      });
+      const parsed = JSON.parse(result.content[0].text);
+
+      expect(parsed.content).toEqual({
+        text: 'Updated note',
+        html: '<p>Updated note</p>',
+      });
+      expect(parsed.is_pinned).toBe(false);
+      expect(mockClient.updateNote).toHaveBeenCalledWith(4, {
+        source: 'Updated note',
+        html: '<p>Updated note</p>',
+        abstract: 'Updated note',
+      });
     });
   });
 });

--- a/tests/tools/remaining.test.ts
+++ b/tests/tools/remaining.test.ts
@@ -14,8 +14,14 @@ beforeEach(() => vi.clearAllMocks());
 describe('searchTools', () => {
   describe('yuque_search', () => {
     it('should search with query and type', async () => {
-      (mockClient.search as ReturnType<typeof vi.fn>).mockResolvedValue({ items: [{ id: 1, type: 'doc', title: 'Result' }], total: 1 });
-      const result = await searchTools.yuque_search.handler(mockClient, { query: 'test', type: 'doc' } as never);
+      (mockClient.search as ReturnType<typeof vi.fn>).mockResolvedValue({
+        items: [{ id: 1, type: 'doc', title: 'Result' }],
+        total: 1,
+      });
+      const result = await searchTools.yuque_search.handler(mockClient, {
+        query: 'test',
+        type: 'doc',
+      } as never);
       expect(result.content[0].type).toBe('text');
       expect(mockClient.search).toHaveBeenCalledWith('test', 'doc');
     });
@@ -32,7 +38,20 @@ describe('tocTools', () => {
   describe('yuque_get_toc', () => {
     it('should get toc', async () => {
       (mockClient.getToc as ReturnType<typeof vi.fn>).mockResolvedValue([
-        { title: 'Ch1', uuid: 'u1', url: '/ch1', prev_uuid: '', sibling_uuid: '', child_uuid: '', parent_uuid: '', doc_id: 1, level: 0, id: 1, open_window: 0, visible: 1 },
+        {
+          title: 'Ch1',
+          uuid: 'u1',
+          url: '/ch1',
+          prev_uuid: '',
+          sibling_uuid: '',
+          child_uuid: '',
+          parent_uuid: '',
+          doc_id: 1,
+          level: 0,
+          id: 1,
+          open_window: 0,
+          visible: 1,
+        },
       ]);
       const result = await tocTools.yuque_get_toc.handler(mockClient, { repo_id: 1 } as never);
       const parsed = JSON.parse(result.content[0].text);
@@ -44,7 +63,10 @@ describe('tocTools', () => {
   describe('yuque_update_toc', () => {
     it('should update toc', async () => {
       (mockClient.updateToc as ReturnType<typeof vi.fn>).mockResolvedValue([]);
-      const result = await tocTools.yuque_update_toc.handler(mockClient, { repo_id: 1, toc: 'new toc' } as never);
+      const result = await tocTools.yuque_update_toc.handler(mockClient, {
+        repo_id: 1,
+        toc: 'new toc',
+      } as never);
       expect(result.content[0].type).toBe('text');
     });
   });

--- a/tests/tools/user.test.ts
+++ b/tests/tools/user.test.ts
@@ -12,8 +12,14 @@ describe('userTools', () => {
   describe('yuque_get_user', () => {
     it('should return formatted user', async () => {
       (mockClient.getUser as ReturnType<typeof vi.fn>).mockResolvedValue({
-        id: 1, type: 'User', login: 'test', name: 'Test', description: '',
-        avatar_url: '', books_count: 5, followers_count: 10,
+        id: 1,
+        type: 'User',
+        login: 'test',
+        name: 'Test',
+        description: '',
+        avatar_url: '',
+        books_count: 5,
+        followers_count: 10,
       });
       const result = await userTools.yuque_get_user.handler(mockClient, {} as never);
       expect(result.content[0].type).toBe('text');

--- a/tests/utils/error.test.ts
+++ b/tests/utils/error.test.ts
@@ -44,6 +44,25 @@ describe('error utilities', () => {
       expect(() => handleYuqueError(axiosError)).toThrow('Unauthorized');
     });
 
+    it.each([
+      [400, 'Bad request'],
+      [403, 'Forbidden'],
+      [404, 'Not found'],
+      [429, 'Rate limited'],
+      [500, 'Yuque server error'],
+    ])('should include status hint for HTTP %s', (status, hint) => {
+      const axiosError = {
+        response: {
+          status,
+          data: {
+            message: 'API failed',
+          },
+        },
+      };
+
+      expect(() => handleYuqueError(axiosError)).toThrow(hint);
+    });
+
     it('should handle error with message', () => {
       const error = { message: 'Network error' };
       expect(() => handleYuqueError(error)).toThrow(YuqueError);

--- a/tests/utils/format.test.ts
+++ b/tests/utils/format.test.ts
@@ -76,20 +76,41 @@ describe('format utilities', () => {
   describe('formatDocSummary', () => {
     it('should format doc summary without body', () => {
       const doc: YuqueDoc = {
-        id: 1, slug: 'test-doc', title: 'Test Doc', book_id: 1, user_id: 1,
-        format: 'markdown', body: 'Test content', body_draft: '',
-        body_html: '<p>Test content</p>', body_lake: '', creator_id: 1,
-        public: 1, status: 1, likes_count: 5, comments_count: 2,
-        content_updated_at: '2024-01-01', deleted_at: null,
-        created_at: '2024-01-01', updated_at: '2024-01-02',
-        published_at: '2024-01-01', first_published_at: '2024-01-01',
-        word_count: 100, cover: null, description: 'Test description',
+        id: 1,
+        slug: 'test-doc',
+        title: 'Test Doc',
+        book_id: 1,
+        user_id: 1,
+        format: 'markdown',
+        body: 'Test content',
+        body_draft: '',
+        body_html: '<p>Test content</p>',
+        body_lake: '',
+        creator_id: 1,
+        public: 1,
+        status: 1,
+        likes_count: 5,
+        comments_count: 2,
+        content_updated_at: '2024-01-01',
+        deleted_at: null,
+        created_at: '2024-01-01',
+        updated_at: '2024-01-02',
+        published_at: '2024-01-01',
+        first_published_at: '2024-01-01',
+        word_count: 100,
+        cover: null,
+        description: 'Test description',
       };
 
       const result = formatDocSummary(doc);
       expect(result).toEqual({
-        id: 1, slug: 'test-doc', title: 'Test Doc', format: 'markdown',
-        public: true, word_count: 100, updated_at: '2024-01-02',
+        id: 1,
+        slug: 'test-doc',
+        title: 'Test Doc',
+        format: 'markdown',
+        public: true,
+        word_count: 100,
+        updated_at: '2024-01-02',
       });
       expect(result).not.toHaveProperty('body');
     });
@@ -97,14 +118,30 @@ describe('format utilities', () => {
 
   describe('formatDoc', () => {
     const doc: YuqueDoc = {
-      id: 1, slug: 'test-doc', title: 'Test Doc', book_id: 1, user_id: 1,
-      format: 'markdown', body: 'Test content', body_draft: '',
-      body_html: '<p>Test content</p>', body_lake: '<!doctype lake>', creator_id: 1,
-      public: 1, status: 1, likes_count: 5, comments_count: 2,
-      content_updated_at: '2024-01-01', deleted_at: null,
-      created_at: '2024-01-01', updated_at: '2024-01-02',
-      published_at: '2024-01-01', first_published_at: '2024-01-01',
-      word_count: 100, cover: null, description: 'Test description',
+      id: 1,
+      slug: 'test-doc',
+      title: 'Test Doc',
+      book_id: 1,
+      user_id: 1,
+      format: 'markdown',
+      body: 'Test content',
+      body_draft: '',
+      body_html: '<p>Test content</p>',
+      body_lake: '<!doctype lake>',
+      creator_id: 1,
+      public: 1,
+      status: 1,
+      likes_count: 5,
+      comments_count: 2,
+      content_updated_at: '2024-01-01',
+      deleted_at: null,
+      created_at: '2024-01-01',
+      updated_at: '2024-01-02',
+      published_at: '2024-01-01',
+      first_published_at: '2024-01-01',
+      word_count: 100,
+      cover: null,
+      description: 'Test description',
     };
 
     it('should format full doc with body', () => {
@@ -133,8 +170,34 @@ describe('format utilities', () => {
   describe('formatToc', () => {
     it('should format TOC items', () => {
       const items: YuqueTocItem[] = [
-        { title: 'Chapter 1', uuid: 'uuid-1', url: '/doc1', prev_uuid: '', sibling_uuid: 'uuid-2', child_uuid: '', parent_uuid: '', doc_id: 1, level: 0, id: 1, open_window: 0, visible: 1 },
-        { title: 'Chapter 2', uuid: 'uuid-2', url: '/doc2', prev_uuid: 'uuid-1', sibling_uuid: '', child_uuid: '', parent_uuid: '', doc_id: 2, level: 0, id: 2, open_window: 0, visible: 0 },
+        {
+          title: 'Chapter 1',
+          uuid: 'uuid-1',
+          url: '/doc1',
+          prev_uuid: '',
+          sibling_uuid: 'uuid-2',
+          child_uuid: '',
+          parent_uuid: '',
+          doc_id: 1,
+          level: 0,
+          id: 1,
+          open_window: 0,
+          visible: 1,
+        },
+        {
+          title: 'Chapter 2',
+          uuid: 'uuid-2',
+          url: '/doc2',
+          prev_uuid: 'uuid-1',
+          sibling_uuid: '',
+          child_uuid: '',
+          parent_uuid: '',
+          doc_id: 2,
+          level: 0,
+          id: 2,
+          open_window: 0,
+          visible: 0,
+        },
       ];
 
       const result = formatToc(items);

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,8 +8,9 @@ export default defineConfig({
     hookTimeout: 10000,
     coverage: {
       provider: 'v8',
+      include: ['src/**/*.ts'],
       reporter: ['text', 'json', 'html'],
-      exclude: ['node_modules/', 'dist/', 'tests/'],
+      exclude: ['node_modules/', 'dist/', 'tests/', 'src/services/types.ts'],
     },
   },
 });


### PR DESCRIPTION
## Summary

- Add focused tests for CLI, HTTP entry, MCP server call handling, install/setup flows, YuqueClient wrappers, note tools, and error handling.
- Configure coverage to include all source files and exclude the pure type definition file.
- Simplify the unreachable non-Windows branch in cli install path handling while preserving platform-specific config coverage.

## Impact

This raises unit line coverage to 100% across the tracked source surface and gives the highest-risk startup and tool-dispatch paths direct regression coverage.

## Validation

- `npm run test:coverage -- --run` — 14 files, 154 tests, Lines 100%
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm run format:check`