### PR TITLE
[codex] Align Yuque token and host contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ MCP server for [Yuque (语雀)](https://www.yuque.com/) — expose your knowledg
 ### 1. Get Your Yuque API Token
 
 Visit [Yuque Developer Settings](https://www.yuque.com/settings/tokens) to create a personal access token.
+If you use a team token from a Yuque space, also prepare that space host, for example `https://your-space.yuque.com`.
 
 ### 2. Quick Install (Recommended)
 
@@ -51,7 +52,7 @@ claude mcp add yuque-mcp -- npx -y yuque-mcp --token=YOUR_TOKEN
 Or using environment variables:
 
 ```bash
-export YUQUE_PERSONAL_TOKEN=YOUR_TOKEN
+export YUQUE_TOKEN=YOUR_TOKEN
 claude mcp add yuque-mcp -- npx -y yuque-mcp
 ```
 
@@ -72,7 +73,7 @@ Add to your `claude_desktop_config.json`:
       "command": "npx",
       "args": ["-y", "yuque-mcp"],
       "env": {
-        "YUQUE_PERSONAL_TOKEN": "YOUR_TOKEN"
+        "YUQUE_TOKEN": "YOUR_TOKEN"
       }
     }
   }
@@ -93,7 +94,7 @@ Add to `.vscode/mcp.json` in your workspace:
       "command": "npx",
       "args": ["-y", "yuque-mcp"],
       "env": {
-        "YUQUE_PERSONAL_TOKEN": "YOUR_TOKEN"
+        "YUQUE_TOKEN": "YOUR_TOKEN"
       }
     }
   }
@@ -116,7 +117,7 @@ Add to your Cursor MCP configuration (`~/.cursor/mcp.json`):
       "command": "npx",
       "args": ["-y", "yuque-mcp"],
       "env": {
-        "YUQUE_PERSONAL_TOKEN": "YOUR_TOKEN"
+        "YUQUE_TOKEN": "YOUR_TOKEN"
       }
     }
   }
@@ -137,7 +138,7 @@ Add to your Windsurf MCP configuration (`~/.windsurf/mcp.json`):
       "command": "npx",
       "args": ["-y", "yuque-mcp"],
       "env": {
-        "YUQUE_PERSONAL_TOKEN": "YOUR_TOKEN"
+        "YUQUE_TOKEN": "YOUR_TOKEN"
       }
     }
   }
@@ -158,7 +159,7 @@ Add to your Cline MCP settings (`~/Library/Application Support/Code/User/globalS
       "command": "npx",
       "args": ["-y", "yuque-mcp"],
       "env": {
-        "YUQUE_PERSONAL_TOKEN": "YOUR_TOKEN"
+        "YUQUE_TOKEN": "YOUR_TOKEN"
       }
     }
   }
@@ -174,13 +175,13 @@ In Trae, open **Settings** and navigate to the **MCP** section, then add a new s
 
 - **Command:** `npx`
 - **Args:** `-y yuque-mcp`
-- **Env:** `YUQUE_PERSONAL_TOKEN=YOUR_TOKEN`
+- **Env:** `YUQUE_TOKEN=YOUR_TOKEN`
 
 See [Trae MCP documentation](https://docs.trae.ai/ide/model-context-protocol) for detailed instructions.
 
 </details>
 
-> **More clients:** Any MCP-compatible client that supports stdio transport can use yuque-mcp. The general pattern is: command = `npx`, args = `["-y", "yuque-mcp"]`, env = `YUQUE_PERSONAL_TOKEN`.
+> **More clients:** Any MCP-compatible client that supports stdio transport can use yuque-mcp. The general pattern is: command = `npx`, args = `["-y", "yuque-mcp"]`, env = `YUQUE_TOKEN`.
 
 </details>
 
@@ -196,27 +197,33 @@ The server supports multiple ways to provide your Yuque API token:
 
 | Method | Environment Variable / Flag | Description |
 |--------|---------------------------|-------------|
-| **Personal Token** (recommended) | `YUQUE_PERSONAL_TOKEN` | For accessing your personal Yuque account |
+| **Token** | `YUQUE_TOKEN` | Personal or team Yuque API token |
+| **Host** | `YUQUE_HOST` / `--host=https://your-space.yuque.com` | Yuque site or space host; required for team tokens tied to a specific space |
 | **CLI Argument** | `--token=YOUR_TOKEN` | Pass directly as a command-line argument |
 
-**Priority order:** `YUQUE_PERSONAL_TOKEN` > `--token`
+**Token priority order:** `YUQUE_TOKEN` > `YUQUE_PERSONAL_TOKEN` > `--token`
 
-### Private Deployment
+**Host priority order:** `YUQUE_HOST` > `--host` > `YUQUE_BASE_URL` > `--base-url`
 
-For privately deployed Yuque instances, set the `YUQUE_BASE_URL` environment variable or use the `--base-url` CLI argument:
+`YUQUE_PERSONAL_TOKEN`, `YUQUE_BASE_URL`, and `--base-url` are kept as legacy fallbacks for existing configs. New configs should use `YUQUE_TOKEN` and `YUQUE_HOST`.
+
+### Team Tokens and Private Deployment
+
+For team tokens, privately deployed Yuque instances, or custom Yuque spaces, set `YUQUE_HOST` or pass `--host`:
 
 ```bash
 # Environment variable
-export YUQUE_BASE_URL=https://yuque.example.com/api/v2
+export YUQUE_TOKEN=YOUR_TOKEN
+export YUQUE_HOST=https://your-space.yuque.com
 
 # CLI argument
-npx yuque-mcp --token=YOUR_TOKEN --base-url=https://yuque.example.com/api/v2
+npx yuque-mcp --token=YOUR_TOKEN --host=https://your-space.yuque.com
 
-# Install with custom base URL
-npx yuque-mcp install --token=YOUR_TOKEN --client=cursor --base-url=https://yuque.example.com/api/v2
+# Install with custom host
+npx yuque-mcp install --token=YOUR_TOKEN --client=cursor --host=https://your-space.yuque.com
 ```
 
-When not set, the default is `https://www.yuque.com/api/v2`.
+The host may be a Yuque site root such as `https://www.yuque.com` or a full API base URL such as `https://www.yuque.com/api/v2`. Host roots are normalized to `/api/v2` at runtime. When not set, the default API base URL is `https://www.yuque.com/api/v2`.
 
 ---
 
@@ -238,7 +245,7 @@ When not set, the default is `https://www.yuque.com/api/v2`.
 
 | Error | Solution |
 |-------|----------|
-| `YUQUE_PERSONAL_TOKEN is required` | Set the environment variable `YUQUE_PERSONAL_TOKEN` or pass `--token=YOUR_TOKEN` |
+| `YUQUE_TOKEN ... is required` | Set `YUQUE_TOKEN=YOUR_TOKEN` or pass `--token=YOUR_TOKEN` |
 | `401 Unauthorized` | Token is invalid or expired — regenerate at [Yuque Settings](https://www.yuque.com/settings/tokens) |
 | `429 Rate Limited` | Too many requests — wait a moment and retry |
 | `410 Gone` | The resource has been permanently deleted or the API endpoint is deprecated — verify the target document/repo still exists |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -14,7 +14,7 @@
 
 ### 1. 获取语雀 API Token
 
-前往 [语雀开发者设置](https://www.yuque.com/settings/tokens) 创建个人访问令牌。
+前往 [语雀开发者设置](https://www.yuque.com/settings/tokens) 创建个人访问令牌。如果使用空间里的团队 Token，也准备对应空间的 host，例如 `https://your-space.yuque.com`。
 
 ### 2. 快速安装（推荐）
 
@@ -24,7 +24,7 @@
 npx yuque-mcp install --token=YOUR_TOKEN --client=cursor
 ```
 
-支持的客户端：`claude-desktop`、`vscode`、`cursor`、`windsurf`、`cline`、`trae`
+支持的客户端：`claude-desktop`、`vscode`、`cursor`、`windsurf`、`cline`、`trae`、`qoder`、`opencode`
 
 或使用交互式安装向导：
 
@@ -51,7 +51,7 @@ claude mcp add yuque-mcp -- npx -y yuque-mcp --token=YOUR_TOKEN
 或使用环境变量：
 
 ```bash
-export YUQUE_PERSONAL_TOKEN=YOUR_TOKEN
+export YUQUE_TOKEN=YOUR_TOKEN
 claude mcp add yuque-mcp -- npx -y yuque-mcp
 ```
 
@@ -72,7 +72,7 @@ claude mcp add yuque-mcp -- npx -y yuque-mcp
       "command": "npx",
       "args": ["-y", "yuque-mcp"],
       "env": {
-        "YUQUE_PERSONAL_TOKEN": "YOUR_TOKEN"
+        "YUQUE_TOKEN": "YOUR_TOKEN"
       }
     }
   }
@@ -93,7 +93,7 @@ claude mcp add yuque-mcp -- npx -y yuque-mcp
       "command": "npx",
       "args": ["-y", "yuque-mcp"],
       "env": {
-        "YUQUE_PERSONAL_TOKEN": "YOUR_TOKEN"
+        "YUQUE_TOKEN": "YOUR_TOKEN"
       }
     }
   }
@@ -116,7 +116,7 @@ claude mcp add yuque-mcp -- npx -y yuque-mcp
       "command": "npx",
       "args": ["-y", "yuque-mcp"],
       "env": {
-        "YUQUE_PERSONAL_TOKEN": "YOUR_TOKEN"
+        "YUQUE_TOKEN": "YOUR_TOKEN"
       }
     }
   }
@@ -137,7 +137,7 @@ claude mcp add yuque-mcp -- npx -y yuque-mcp
       "command": "npx",
       "args": ["-y", "yuque-mcp"],
       "env": {
-        "YUQUE_PERSONAL_TOKEN": "YOUR_TOKEN"
+        "YUQUE_TOKEN": "YOUR_TOKEN"
       }
     }
   }
@@ -158,7 +158,7 @@ claude mcp add yuque-mcp -- npx -y yuque-mcp
       "command": "npx",
       "args": ["-y", "yuque-mcp"],
       "env": {
-        "YUQUE_PERSONAL_TOKEN": "YOUR_TOKEN"
+        "YUQUE_TOKEN": "YOUR_TOKEN"
       }
     }
   }
@@ -174,13 +174,13 @@ claude mcp add yuque-mcp -- npx -y yuque-mcp
 
 - **Command:** `npx`
 - **Args:** `-y yuque-mcp`
-- **Env:** `YUQUE_PERSONAL_TOKEN=YOUR_TOKEN`
+- **Env:** `YUQUE_TOKEN=YOUR_TOKEN`
 
 详见 [Trae MCP 文档](https://docs.trae.ai/ide/model-context-protocol)。
 
 </details>
 
-> **更多客户端：** 任何支持 stdio 传输的 MCP 客户端均可使用 yuque-mcp。通用配置：command = `npx`，args = `["-y", "yuque-mcp"]`，env = `YUQUE_PERSONAL_TOKEN`。
+> **更多客户端：** 任何支持 stdio 传输的 MCP 客户端均可使用 yuque-mcp。通用配置：command = `npx`，args = `["-y", "yuque-mcp"]`，env = `YUQUE_TOKEN`。
 
 </details>
 
@@ -196,27 +196,33 @@ claude mcp add yuque-mcp -- npx -y yuque-mcp
 
 | 方式 | 环境变量 / 参数 | 说明 |
 |------|----------------|------|
-| **个人 Token**（推荐） | `YUQUE_PERSONAL_TOKEN` | 访问个人语雀账号 |
+| **Token** | `YUQUE_TOKEN` | 个人或团队语雀 API Token |
+| **Host** | `YUQUE_HOST` / `--host=https://your-space.yuque.com` | 语雀站点或空间 host；使用绑定空间的团队 Token 时必须设置 |
 | **CLI 参数** | `--token=YOUR_TOKEN` | 通过命令行参数传入 |
 
-**优先级：** `YUQUE_PERSONAL_TOKEN` > `--token`
+**Token 优先级：** `YUQUE_TOKEN` > `YUQUE_PERSONAL_TOKEN` > `--token`
 
-### 私有化部署
+**Host 优先级：** `YUQUE_HOST` > `--host` > `YUQUE_BASE_URL` > `--base-url`
 
-如果使用私有化部署的语雀实例，设置 `YUQUE_BASE_URL` 环境变量或使用 `--base-url` CLI 参数：
+`YUQUE_PERSONAL_TOKEN`、`YUQUE_BASE_URL` 和 `--base-url` 继续作为旧配置的兼容 fallback。新配置建议使用 `YUQUE_TOKEN` 和 `YUQUE_HOST`。
+
+### 团队 Token 与私有化部署
+
+如果使用团队 Token、私有化部署实例或自定义语雀空间，设置 `YUQUE_HOST` 环境变量或使用 `--host` CLI 参数：
 
 ```bash
 # 环境变量
-export YUQUE_BASE_URL=https://yuque.example.com/api/v2
+export YUQUE_TOKEN=YOUR_TOKEN
+export YUQUE_HOST=https://your-space.yuque.com
 
 # CLI 参数
-npx yuque-mcp --token=YOUR_TOKEN --base-url=https://yuque.example.com/api/v2
+npx yuque-mcp --token=YOUR_TOKEN --host=https://your-space.yuque.com
 
 # 安装时指定
-npx yuque-mcp install --token=YOUR_TOKEN --client=cursor --base-url=https://yuque.example.com/api/v2
+npx yuque-mcp install --token=YOUR_TOKEN --client=cursor --host=https://your-space.yuque.com
 ```
 
-不设置时默认为 `https://www.yuque.com/api/v2`。
+`YUQUE_HOST` 可以是语雀站点根地址，例如 `https://www.yuque.com`，也可以是完整 API base URL，例如 `https://www.yuque.com/api/v2`。运行时会把站点根地址规范化到 `/api/v2`。不设置时默认 API base URL 为 `https://www.yuque.com/api/v2`。
 
 ---
 
@@ -238,7 +244,7 @@ npx yuque-mcp install --token=YOUR_TOKEN --client=cursor --base-url=https://yuqu
 
 | 错误 | 解决方案 |
 |------|----------|
-| `YUQUE_PERSONAL_TOKEN is required` | 设置环境变量 `YUQUE_PERSONAL_TOKEN` 或传入 `--token=YOUR_TOKEN` |
+| `YUQUE_TOKEN ... is required` | 设置 `YUQUE_TOKEN=YOUR_TOKEN` 或传入 `--token=YOUR_TOKEN` |
 | `401 Unauthorized` | Token 无效或已过期 — 到[语雀设置](https://www.yuque.com/settings/tokens)重新生成 |
 | `429 Rate Limited` | 请求过于频繁，等待后重试 |
 | 找不到工具 | 更新到最新版本：`npx -y yuque-mcp@latest` |

--- a/scripts/cli-smoke-utils.js
+++ b/scripts/cli-smoke-utils.js
@@ -4,7 +4,7 @@ import path from 'node:path';
 import process from 'node:process';
 
 export const EXPECTED_MISSING_TOKEN_MESSAGE =
-  'Error: YUQUE_PERSONAL_TOKEN environment variable or --token argument is required';
+  'Error: YUQUE_TOKEN environment variable, YUQUE_PERSONAL_TOKEN environment variable, or --token argument is required';
 
 const DEFAULT_TIMEOUT_MS = 5000;
 
@@ -23,6 +23,7 @@ export async function assertCliStartsAndFailsWithoutToken(
     cwd,
     env: {
       ...process.env,
+      YUQUE_TOKEN: '',
       YUQUE_PERSONAL_TOKEN: '',
     },
     stdio: [ 'pipe', 'pipe', 'pipe' ],

--- a/server.json
+++ b/server.json
@@ -6,35 +6,28 @@
     "url": "https://github.com/yuque/yuque-mcp-server",
     "source": "github"
   },
-  "version": "0.1.4",
+  "version": "1.0.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "yuque-mcp",
-      "version": "0.1.4",
+      "version": "1.0.0",
       "transport": {
         "type": "stdio"
       },
       "environmentVariables": [
         {
-          "name": "YUQUE_PERSONAL_TOKEN",
-          "description": "Yuque personal API token (get from https://www.yuque.com/settings/tokens). Use one of: YUQUE_PERSONAL_TOKEN, YUQUE_GROUP_TOKEN, or YUQUE_TOKEN.",
-          "isRequired": false,
-          "isSecret": true,
-          "format": "string"
-        },
-        {
-          "name": "YUQUE_GROUP_TOKEN",
-          "description": "Yuque group/team API token (alternative to YUQUE_PERSONAL_TOKEN for team workspaces).",
-          "isRequired": false,
-          "isSecret": true,
-          "format": "string"
-        },
-        {
           "name": "YUQUE_TOKEN",
-          "description": "Yuque API token (legacy, use YUQUE_PERSONAL_TOKEN or YUQUE_GROUP_TOKEN instead).",
-          "isRequired": false,
+          "description": "Yuque API token. Use a personal token for your account, or a team token together with YUQUE_HOST for the matching Yuque space.",
+          "isRequired": true,
           "isSecret": true,
+          "format": "string"
+        },
+        {
+          "name": "YUQUE_HOST",
+          "description": "Yuque site or space host, for example https://www.yuque.com or https://your-space.yuque.com. Required when using a team token from a specific space.",
+          "isRequired": false,
+          "isSecret": false,
           "format": "string"
         }
       ]

--- a/src/cli-install.ts
+++ b/src/cli-install.ts
@@ -20,7 +20,7 @@ interface ClientConfig {
   configKey: 'mcpServers' | 'servers' | 'mcp';
   getConfigPath: () => string;
   /** Custom function to build the server entry for this client (if different from the default). */
-  buildEntry?: (token: string, baseURL?: string) => Record<string, unknown>;
+  buildEntry?: (token: string, host?: string) => Record<string, unknown>;
 }
 
 function getAppDataPath(): string {
@@ -173,9 +173,8 @@ const CLIENT_CONFIGS: Record<ClientId, ClientConfig> = {
     getConfigPath() {
       return path.join(process.cwd(), 'opencode.json');
     },
-    buildEntry(token: string, baseURL?: string) {
-      const env: Record<string, string> = { YUQUE_PERSONAL_TOKEN: token };
-      if (baseURL) env.YUQUE_BASE_URL = baseURL;
+    buildEntry(token: string, host?: string) {
+      const env = buildMcpEnv(token, host);
       return {
         type: 'local',
         command: ['npx', '-y', 'yuque-mcp'],
@@ -188,13 +187,17 @@ const CLIENT_CONFIGS: Record<ClientId, ClientConfig> = {
 
 // ─── Config Generation ────────────────────────────────────────────────
 
-function buildServerEntry(token: string, baseURL?: string) {
-  const env: Record<string, string> = { YUQUE_PERSONAL_TOKEN: token };
-  if (baseURL) env.YUQUE_BASE_URL = baseURL;
+function buildMcpEnv(token: string, host?: string): Record<string, string> {
+  const env: Record<string, string> = { YUQUE_TOKEN: token };
+  if (host) env.YUQUE_HOST = host;
+  return env;
+}
+
+function buildServerEntry(token: string, host?: string) {
   return {
     command: 'npx',
     args: ['-y', 'yuque-mcp'],
-    env,
+    env: buildMcpEnv(token, host),
   };
 }
 
@@ -203,6 +206,8 @@ function buildServerEntry(token: string, baseURL?: string) {
 export interface InstallOptions {
   token: string;
   client: ClientId;
+  host?: string;
+  /** @deprecated Use host. Kept so older callers can still generate config. */
   baseURL?: string;
 }
 
@@ -251,9 +256,10 @@ export function installToClient(options: InstallOptions): string {
 
   // Inject/update the yuque entry
   const serversObj = config[configKey] as Record<string, unknown>;
+  const host = options.host ?? options.baseURL;
   serversObj['yuque'] = clientConfig.buildEntry
-    ? clientConfig.buildEntry(options.token, options.baseURL)
-    : buildServerEntry(options.token, options.baseURL);
+    ? clientConfig.buildEntry(options.token, host)
+    : buildServerEntry(options.token, host);
 
   // Create parent directories if needed
   const dir = path.dirname(configPath);
@@ -270,29 +276,27 @@ export function installToClient(options: InstallOptions): string {
 export function runInstall(args: string[]): void {
   const tokenArg = args.find((a) => a.startsWith('--token='));
   const clientArg = args.find((a) => a.startsWith('--client='));
+  const hostArg = args.find((a) => a.startsWith('--host='));
   const baseURLArg = args.find((a) => a.startsWith('--base-url='));
 
   if (!tokenArg) {
     console.error('Error: --token=YOUR_TOKEN is required.');
-    console.error(
-      'Usage: npx yuque-mcp install --token=YOUR_TOKEN --client=CLIENT [--base-url=URL]'
-    );
+    console.error('Usage: npx yuque-mcp install --token=YOUR_TOKEN --client=CLIENT [--host=HOST]');
     console.error(`Supported clients: ${getSupportedClients().join(', ')}`);
     process.exit(1);
   }
 
   if (!clientArg) {
     console.error('Error: --client=CLIENT is required.');
-    console.error(
-      'Usage: npx yuque-mcp install --token=YOUR_TOKEN --client=CLIENT [--base-url=URL]'
-    );
+    console.error('Usage: npx yuque-mcp install --token=YOUR_TOKEN --client=CLIENT [--host=HOST]');
     console.error(`Supported clients: ${getSupportedClients().join(', ')}`);
     process.exit(1);
   }
 
   const token = tokenArg.split('=').slice(1).join('=');
   const client = clientArg.split('=').slice(1).join('=') as ClientId;
-  const baseURL = baseURLArg?.split('=').slice(1).join('=');
+  const host =
+    hostArg?.split('=').slice(1).join('=') ?? baseURLArg?.split('=').slice(1).join('=');
 
   if (!token) {
     console.error('Error: Token value cannot be empty.');
@@ -300,7 +304,7 @@ export function runInstall(args: string[]): void {
   }
 
   try {
-    const configPath = installToClient({ token, client, baseURL });
+    const configPath = installToClient({ token, client, host });
     const clientName = CLIENT_CONFIGS[client]?.name ?? client;
     console.log(`\n✅ Successfully configured yuque-mcp for ${clientName}!`);
     console.log(`   Config file: ${configPath}`);
@@ -361,14 +365,14 @@ export async function runSetup(): Promise<void> {
 
     const client = clients[idx];
 
-    // Step 3: Ask for base URL (optional, for private deployments)
-    console.log('\nStep 3: Enter your Yuque API base URL (optional)');
-    console.log('   (Leave empty for https://www.yuque.com/api/v2)\n');
-    const baseURL = (await askQuestion(rl, '   Base URL: ')) || undefined;
+    // Step 3: Ask for host (optional, for team tokens or private deployments)
+    console.log('\nStep 3: Enter your Yuque host (optional)');
+    console.log('   (Leave empty for https://www.yuque.com)\n');
+    const host = (await askQuestion(rl, '   Host: ')) || undefined;
 
     // Step 4: Install
     console.log('');
-    const configPath = installToClient({ token, client, baseURL });
+    const configPath = installToClient({ token, client, host });
     const clientName = CLIENT_CONFIGS[client].name;
     console.log(`✅ Successfully configured yuque-mcp for ${clientName}!`);
     console.log(`   Config file: ${configPath}`);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import { createRequire } from 'node:module';
 import { handleCliSubcommands } from './cli-install.js';
+import { MISSING_TOKEN_MESSAGE, resolveYuqueBaseURL, resolveYuqueToken } from './config.js';
 import { runStdioServer } from './server.js';
 
 // Handle install/setup subcommands before starting the MCP server
@@ -9,14 +10,10 @@ if (handleCliSubcommands(process.argv)) {
   // For async subcommands (setup), the process will exit when done.
 } else {
   // Normal MCP server startup
-  const token =
-    process.env.YUQUE_PERSONAL_TOKEN ||
-    process.argv.find((arg) => arg.startsWith('--token='))?.split('=')[1];
+  const token = resolveYuqueToken();
 
   if (!token) {
-    console.error(
-      'Error: YUQUE_PERSONAL_TOKEN environment variable or --token argument is required'
-    );
+    console.error(MISSING_TOKEN_MESSAGE);
     process.exit(1);
   }
 
@@ -48,9 +45,7 @@ if (handleCliSubcommands(process.argv)) {
     process.exit(0);
   }
 
-  const baseURL =
-    process.env.YUQUE_BASE_URL ||
-    process.argv.find((arg) => arg.startsWith('--base-url='))?.split('=')[1];
+  const baseURL = resolveYuqueBaseURL();
 
   runStdioServer(token, baseURL).catch((error) => {
     console.error('Fatal error:', error);

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,42 @@
+export const MISSING_TOKEN_MESSAGE =
+  'Error: YUQUE_TOKEN environment variable, YUQUE_PERSONAL_TOKEN environment variable, or --token argument is required';
+
+function readArg(argv: string[], name: string): string | undefined {
+  return argv.find((arg) => arg.startsWith(`--${name}=`))?.split('=').slice(1).join('=');
+}
+
+export function normalizeYuqueBaseURL(value: string | undefined): string | undefined {
+  const raw = value?.trim();
+  if (!raw) return undefined;
+
+  const withoutTrailingSlash = raw.replace(/\/+$/, '');
+
+  try {
+    const url = new URL(withoutTrailingSlash);
+    const pathname = url.pathname.replace(/\/+$/, '');
+    if (!pathname || pathname === '/') {
+      url.pathname = '/api/v2';
+      return url.toString().replace(/\/+$/, '');
+    }
+    return withoutTrailingSlash;
+  } catch {
+    return withoutTrailingSlash;
+  }
+}
+
+export function resolveYuqueToken(
+  argv: string[] = process.argv,
+  env: NodeJS.ProcessEnv = process.env
+): string | undefined {
+  return env.YUQUE_TOKEN || env.YUQUE_PERSONAL_TOKEN || readArg(argv, 'token');
+}
+
+export function resolveYuqueBaseURL(
+  argv: string[] = process.argv,
+  env: NodeJS.ProcessEnv = process.env
+): string | undefined {
+  const hostOrBaseURL =
+    env.YUQUE_HOST || readArg(argv, 'host') || env.YUQUE_BASE_URL || readArg(argv, 'base-url');
+
+  return normalizeYuqueBaseURL(hostOrBaseURL);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,19 +2,16 @@ import { createServer as createMCPServer } from './server.js';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import { createServer } from 'node:http';
 import { randomUUID } from 'node:crypto';
+import { MISSING_TOKEN_MESSAGE, resolveYuqueBaseURL, resolveYuqueToken } from './config.js';
 
-const token =
-  process.env.YUQUE_PERSONAL_TOKEN ||
-  process.argv.find((arg) => arg.startsWith('--token='))?.split('=')[1];
+const token = resolveYuqueToken();
 
 if (!token) {
-  console.error('Error: YUQUE_PERSONAL_TOKEN environment variable or --token argument is required');
+  console.error(MISSING_TOKEN_MESSAGE);
   process.exit(1);
 }
 
-const baseURL =
-  process.env.YUQUE_BASE_URL ||
-  process.argv.find((arg) => arg.startsWith('--base-url='))?.split('=')[1];
+const baseURL = resolveYuqueBaseURL();
 
 const mcpServer = createMCPServer(token, baseURL);
 const transport = new StreamableHTTPServerTransport({

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -15,7 +15,7 @@ function statusHint(status: number): string {
     case 400:
       return 'Bad request — check the parameters';
     case 401:
-      return 'Unauthorized — the API token (YUQUE_PERSONAL_TOKEN) may be invalid or expired';
+      return 'Unauthorized — the API token (YUQUE_TOKEN) may be invalid or expired';
     case 403:
       return 'Forbidden — insufficient permissions for this resource';
     case 404:

--- a/tests/cli-install-setup.test.ts
+++ b/tests/cli-install-setup.test.ts
@@ -62,14 +62,14 @@ describe('runSetup', () => {
     const clientConfig = module.getClientConfig('claude-desktop');
     if (!clientConfig) throw new Error('claude-desktop config missing');
     clientConfig.getConfigPath = () => configPath;
-    readlineMock.answers = ['setup-token', '1', 'https://yuque.internal/api/v2'];
+    readlineMock.answers = ['setup-token', '1', 'https://yuque.internal'];
 
     await module.runSetup();
 
     const content = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
     expect(content.mcpServers.yuque.env).toEqual({
-      YUQUE_PERSONAL_TOKEN: 'setup-token',
-      YUQUE_BASE_URL: 'https://yuque.internal/api/v2',
+      YUQUE_TOKEN: 'setup-token',
+      YUQUE_HOST: 'https://yuque.internal',
     });
     expect(readlineMock.close).toHaveBeenCalledTimes(1);
     expect(log).toHaveBeenCalledWith(expect.stringContaining('Successfully configured'));

--- a/tests/cli-install.test.ts
+++ b/tests/cli-install.test.ts
@@ -185,7 +185,7 @@ describe('installToClient', () => {
           command: 'npx',
           args: ['-y', 'yuque-mcp'],
           env: {
-            YUQUE_PERSONAL_TOKEN: 'test-token-123',
+            YUQUE_TOKEN: 'test-token-123',
           },
         },
       },
@@ -206,7 +206,7 @@ describe('installToClient', () => {
           command: 'npx',
           args: ['-y', 'yuque-mcp'],
           env: {
-            YUQUE_PERSONAL_TOKEN: 'vsc-token',
+            YUQUE_TOKEN: 'vsc-token',
           },
         },
       },
@@ -247,7 +247,7 @@ describe('installToClient', () => {
       command: 'npx',
       args: ['-y', 'yuque-mcp'],
       env: {
-        YUQUE_PERSONAL_TOKEN: 'merge-token',
+        YUQUE_TOKEN: 'merge-token',
       },
     });
   });
@@ -264,7 +264,7 @@ describe('installToClient', () => {
               command: 'npx',
               args: ['-y', 'yuque-mcp'],
               env: {
-                YUQUE_PERSONAL_TOKEN: 'old-token',
+                YUQUE_TOKEN: 'old-token',
               },
             },
           },
@@ -279,7 +279,7 @@ describe('installToClient', () => {
     installToClient({ token: 'new-token', client: 'cursor' });
 
     const content = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
-    expect(content.mcpServers['yuque'].env.YUQUE_PERSONAL_TOKEN).toBe('new-token');
+    expect(content.mcpServers['yuque'].env.YUQUE_TOKEN).toBe('new-token');
     // Should only have one entry
     expect(Object.keys(content.mcpServers)).toEqual(['yuque']);
   });
@@ -308,7 +308,24 @@ describe('installToClient', () => {
     expect(content.mcpServers.yuque).toBeDefined();
   });
 
-  it('should include custom base URL in standard client env', () => {
+  it('should include custom host in standard client env', () => {
+    const configPath = path.join(tmpDir, 'host', 'mcp.json');
+    mockConfigPath('cursor', configPath);
+
+    installToClient({
+      token: 'host-token',
+      client: 'cursor',
+      host: 'https://yuque.internal',
+    });
+
+    const content = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+    expect(content.mcpServers.yuque.env).toEqual({
+      YUQUE_TOKEN: 'host-token',
+      YUQUE_HOST: 'https://yuque.internal',
+    });
+  });
+
+  it('should keep legacy baseURL callers working', () => {
     const configPath = path.join(tmpDir, 'base-url', 'mcp.json');
     mockConfigPath('cursor', configPath);
 
@@ -320,8 +337,8 @@ describe('installToClient', () => {
 
     const content = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
     expect(content.mcpServers.yuque.env).toEqual({
-      YUQUE_PERSONAL_TOKEN: 'base-token',
-      YUQUE_BASE_URL: 'https://yuque.internal/api/v2',
+      YUQUE_TOKEN: 'base-token',
+      YUQUE_HOST: 'https://yuque.internal/api/v2',
     });
   });
 
@@ -333,7 +350,7 @@ describe('installToClient', () => {
 
     expect(fs.existsSync(configPath)).toBe(true);
     const content = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
-    expect(content.mcpServers.yuque.env.YUQUE_PERSONAL_TOKEN).toBe('deep-token');
+    expect(content.mcpServers.yuque.env.YUQUE_TOKEN).toBe('deep-token');
   });
 
   it('should throw for unknown client', () => {
@@ -354,7 +371,7 @@ describe('installToClient', () => {
     expect(fs.existsSync(configPath + '.backup')).toBe(true);
     // New valid config should exist
     const content = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
-    expect(content.mcpServers.yuque.env.YUQUE_PERSONAL_TOKEN).toBe('fix-token');
+    expect(content.mcpServers.yuque.env.YUQUE_TOKEN).toBe('fix-token');
   });
 
   it('should work for claude-desktop client', () => {
@@ -407,7 +424,7 @@ describe('installToClient', () => {
     const content = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
     expect(content.mcpServers.yuque).toBeDefined();
     expect(content.mcpServers.yuque.command).toBe('npx');
-    expect(content.mcpServers.yuque.env.YUQUE_PERSONAL_TOKEN).toBe('qoder-tok');
+    expect(content.mcpServers.yuque.env.YUQUE_TOKEN).toBe('qoder-tok');
   });
 
   it('should work for opencode client with custom format', () => {
@@ -422,7 +439,7 @@ describe('installToClient', () => {
       type: 'local',
       command: ['npx', '-y', 'yuque-mcp'],
       environment: {
-        YUQUE_PERSONAL_TOKEN: 'opencode-tok',
+        YUQUE_TOKEN: 'opencode-tok',
       },
       enabled: true,
     });
@@ -430,20 +447,20 @@ describe('installToClient', () => {
     expect(content.mcpServers).toBeUndefined();
   });
 
-  it('should include custom base URL in opencode environment', () => {
-    const configPath = path.join(tmpDir, 'opencode-base-url', 'opencode.json');
+  it('should include custom host in opencode environment', () => {
+    const configPath = path.join(tmpDir, 'opencode-host', 'opencode.json');
     mockConfigPath('opencode', configPath);
 
     installToClient({
-      token: 'opencode-base-token',
+      token: 'opencode-host-token',
       client: 'opencode',
-      baseURL: 'https://yuque.internal/api/v2',
+      host: 'https://yuque.internal',
     });
 
     const content = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
     expect(content.mcp.yuque.environment).toEqual({
-      YUQUE_PERSONAL_TOKEN: 'opencode-base-token',
-      YUQUE_BASE_URL: 'https://yuque.internal/api/v2',
+      YUQUE_TOKEN: 'opencode-host-token',
+      YUQUE_HOST: 'https://yuque.internal',
     });
   });
 
@@ -484,7 +501,7 @@ describe('installToClient', () => {
       type: 'local',
       command: ['npx', '-y', 'yuque-mcp'],
       environment: {
-        YUQUE_PERSONAL_TOKEN: 'oc-merge-tok',
+        YUQUE_TOKEN: 'oc-merge-tok',
       },
       enabled: true,
     });
@@ -518,7 +535,7 @@ describe('installToClient', () => {
     expect(content.servers['github-copilot']).toBeDefined();
     // Yuque added under 'servers' (not 'mcpServers')
     expect(content.servers['yuque']).toBeDefined();
-    expect(content.servers['yuque'].env.YUQUE_PERSONAL_TOKEN).toBe('vsc-merge-tok');
+    expect(content.servers['yuque'].env.YUQUE_TOKEN).toBe('vsc-merge-tok');
     // No mcpServers key should exist
     expect(content.mcpServers).toBeUndefined();
   });
@@ -533,15 +550,33 @@ describe('runInstall', () => {
     runInstall([
       '--token=token=with=equals',
       '--client=cursor',
+      '--host=https://yuque.internal',
+    ]);
+
+    const content = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+    expect(content.mcpServers.yuque.env).toEqual({
+      YUQUE_TOKEN: 'token=with=equals',
+      YUQUE_HOST: 'https://yuque.internal',
+    });
+    expect(log).toHaveBeenCalledWith(expect.stringContaining('Successfully configured'));
+  });
+
+  it('should accept legacy --base-url in CLI arguments', () => {
+    const configPath = path.join(tmpDir, 'run-install-base-url', 'mcp.json');
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    mockConfigPath('cursor', configPath);
+
+    runInstall([
+      '--token=token=with=equals',
+      '--client=cursor',
       '--base-url=https://yuque.internal/api/v2',
     ]);
 
     const content = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
     expect(content.mcpServers.yuque.env).toEqual({
-      YUQUE_PERSONAL_TOKEN: 'token=with=equals',
-      YUQUE_BASE_URL: 'https://yuque.internal/api/v2',
+      YUQUE_TOKEN: 'token=with=equals',
+      YUQUE_HOST: 'https://yuque.internal/api/v2',
     });
-    expect(log).toHaveBeenCalledWith(expect.stringContaining('Successfully configured'));
   });
 
   it('should exit when token argument is missing', () => {

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -14,8 +14,10 @@ vi.mock('../src/server.js', () => ({
 }));
 
 const originalArgv = process.argv;
-const originalToken = process.env.YUQUE_PERSONAL_TOKEN;
-const originalBaseURL = process.env.YUQUE_BASE_URL;
+const originalToken = process.env.YUQUE_TOKEN;
+const originalLegacyToken = process.env.YUQUE_PERSONAL_TOKEN;
+const originalHost = process.env.YUQUE_HOST;
+const originalLegacyBaseURL = process.env.YUQUE_BASE_URL;
 const originalIsTTY = Object.getOwnPropertyDescriptor(process.stdin, 'isTTY');
 let cliImportRun = 0;
 
@@ -63,7 +65,9 @@ describe('CLI entry', () => {
     cliMocks.handleCliSubcommands.mockReturnValue(false);
     cliMocks.runStdioServer.mockResolvedValue(undefined);
     process.argv = ['node', 'cli.js'];
+    delete process.env.YUQUE_TOKEN;
     delete process.env.YUQUE_PERSONAL_TOKEN;
+    delete process.env.YUQUE_HOST;
     delete process.env.YUQUE_BASE_URL;
     setIsTTY(false);
   });
@@ -71,8 +75,10 @@ describe('CLI entry', () => {
   afterEach(() => {
     vi.restoreAllMocks();
     process.argv = originalArgv;
-    restoreEnv('YUQUE_PERSONAL_TOKEN', originalToken);
-    restoreEnv('YUQUE_BASE_URL', originalBaseURL);
+    restoreEnv('YUQUE_TOKEN', originalToken);
+    restoreEnv('YUQUE_PERSONAL_TOKEN', originalLegacyToken);
+    restoreEnv('YUQUE_HOST', originalHost);
+    restoreEnv('YUQUE_BASE_URL', originalLegacyBaseURL);
     if (originalIsTTY) {
       Object.defineProperty(process.stdin, 'isTTY', originalIsTTY);
     }
@@ -95,13 +101,13 @@ describe('CLI entry', () => {
     await expect(importCli()).rejects.toThrow('exit:1');
 
     expect(error).toHaveBeenCalledWith(
-      'Error: YUQUE_PERSONAL_TOKEN environment variable or --token argument is required'
+      'Error: YUQUE_TOKEN environment variable, YUQUE_PERSONAL_TOKEN environment variable, or --token argument is required'
     );
   });
 
   it('should print terminal guidance when run directly in a TTY', async () => {
     const log = vi.spyOn(console, 'log').mockImplementation(() => {});
-    process.env.YUQUE_PERSONAL_TOKEN = 'env-token';
+    process.env.YUQUE_TOKEN = 'env-token';
     setIsTTY(true);
     mockExit();
 
@@ -116,7 +122,7 @@ describe('CLI entry', () => {
       'node',
       'cli.js',
       '--token=arg-token',
-      '--base-url=https://yuque.internal/api/v2',
+      '--host=https://yuque.internal',
     ];
 
     await importCli();
@@ -129,7 +135,7 @@ describe('CLI entry', () => {
 
   it('should exit when stdio startup fails', async () => {
     const error = vi.spyOn(console, 'error').mockImplementation(() => {});
-    process.env.YUQUE_PERSONAL_TOKEN = 'env-token';
+    process.env.YUQUE_TOKEN = 'env-token';
     cliMocks.runStdioServer.mockRejectedValue(new Error('stdio failed'));
     mockExit(false);
 

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -42,8 +42,10 @@ vi.mock('node:crypto', () => ({
 }));
 
 const originalArgv = process.argv;
-const originalToken = process.env.YUQUE_PERSONAL_TOKEN;
-const originalBaseURL = process.env.YUQUE_BASE_URL;
+const originalToken = process.env.YUQUE_TOKEN;
+const originalLegacyToken = process.env.YUQUE_PERSONAL_TOKEN;
+const originalHost = process.env.YUQUE_HOST;
+const originalLegacyBaseURL = process.env.YUQUE_BASE_URL;
 const originalPort = process.env.PORT;
 let indexImportRun = 0;
 
@@ -89,7 +91,9 @@ describe('HTTP entry', () => {
     indexMocks.httpHandler = undefined;
     indexMocks.sessionId = undefined;
     process.argv = ['node', 'index.js'];
+    delete process.env.YUQUE_TOKEN;
     delete process.env.YUQUE_PERSONAL_TOKEN;
+    delete process.env.YUQUE_HOST;
     delete process.env.YUQUE_BASE_URL;
     delete process.env.PORT;
   });
@@ -97,8 +101,10 @@ describe('HTTP entry', () => {
   afterEach(() => {
     vi.restoreAllMocks();
     process.argv = originalArgv;
-    restoreEnv('YUQUE_PERSONAL_TOKEN', originalToken);
-    restoreEnv('YUQUE_BASE_URL', originalBaseURL);
+    restoreEnv('YUQUE_TOKEN', originalToken);
+    restoreEnv('YUQUE_PERSONAL_TOKEN', originalLegacyToken);
+    restoreEnv('YUQUE_HOST', originalHost);
+    restoreEnv('YUQUE_BASE_URL', originalLegacyBaseURL);
     restoreEnv('PORT', originalPort);
   });
 
@@ -109,7 +115,7 @@ describe('HTTP entry', () => {
     await expect(importHttpEntry()).rejects.toThrow('exit:1');
 
     expect(error).toHaveBeenCalledWith(
-      'Error: YUQUE_PERSONAL_TOKEN environment variable or --token argument is required'
+      'Error: YUQUE_TOKEN environment variable, YUQUE_PERSONAL_TOKEN environment variable, or --token argument is required'
     );
   });
 
@@ -120,7 +126,7 @@ describe('HTTP entry', () => {
       'node',
       'index.js',
       '--token=arg-token',
-      '--base-url=https://yuque.internal/api/v2',
+      '--host=https://yuque.internal',
     ];
     process.env.PORT = '4242';
 
@@ -150,8 +156,8 @@ describe('HTTP entry', () => {
 
   it('should use environment token and default port', async () => {
     const log = vi.spyOn(console, 'log').mockImplementation(() => {});
-    process.env.YUQUE_PERSONAL_TOKEN = 'env-token';
-    process.env.YUQUE_BASE_URL = 'https://env.example/api/v2';
+    process.env.YUQUE_TOKEN = 'env-token';
+    process.env.YUQUE_HOST = 'https://env.example';
 
     await importHttpEntry();
     await Promise.resolve();
@@ -166,7 +172,7 @@ describe('HTTP entry', () => {
 
   it('should exit when MCP server connection fails', async () => {
     const error = vi.spyOn(console, 'error').mockImplementation(() => {});
-    process.env.YUQUE_PERSONAL_TOKEN = 'env-token';
+    process.env.YUQUE_TOKEN = 'env-token';
     indexMocks.connect.mockRejectedValue(new Error('connect failed'));
     mockExit(false);
 

--- a/tests/mcp/server-manifest-contract.test.ts
+++ b/tests/mcp/server-manifest-contract.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import serverManifest from '../../server.json';
+
+type ServerManifest = {
+  packages: Array<{
+    environmentVariables?: Array<{
+      name: string;
+      isRequired: boolean;
+      isSecret: boolean;
+    }>;
+  }>;
+};
+
+describe('MCP server manifest contract', () => {
+  it('should expose only the supported Yuque token and host variables', () => {
+    const manifest = serverManifest as ServerManifest;
+    const envVars = manifest.packages[0]?.environmentVariables ?? [];
+
+    expect(envVars.map((envVar) => envVar.name)).toEqual(['YUQUE_TOKEN', 'YUQUE_HOST']);
+    expect(envVars).toEqual([
+      expect.objectContaining({
+        name: 'YUQUE_TOKEN',
+        isRequired: true,
+        isSecret: true,
+      }),
+      expect.objectContaining({
+        name: 'YUQUE_HOST',
+        isRequired: false,
+        isSecret: false,
+      }),
+    ]);
+  });
+});

--- a/tests/real-api/smoke.test.ts
+++ b/tests/real-api/smoke.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest';
+import { resolveYuqueBaseURL } from '../../src/config.js';
 import { createServer } from '../../src/server.js';
 
 type ToolResult = {
@@ -20,7 +21,9 @@ const realApiEnabled = process.env.YUQUE_REAL_API === '1';
 const repoId = process.env.YUQUE_REAL_REPO_ID;
 const noteId = process.env.YUQUE_REAL_WRITE_NOTE_ID;
 const writeEnabled = realApiEnabled && process.env.YUQUE_REAL_WRITE === '1' && noteId;
-const token = process.env.YUQUE_PERSONAL_TOKEN ?? process.env.YUQUE_MCP_TEST_TOKEN;
+const token =
+  process.env.YUQUE_TOKEN ?? process.env.YUQUE_PERSONAL_TOKEN ?? process.env.YUQUE_MCP_TEST_TOKEN;
+const baseURL = resolveYuqueBaseURL(['node', 'smoke.test.ts'], process.env);
 
 function getRequestHandler<T>(server: unknown, method: string) {
   return (
@@ -33,10 +36,10 @@ function getRequestHandler<T>(server: unknown, method: string) {
 async function callRealTool(name: string, args: Record<string, unknown>) {
   if (!token) {
     throw new Error(
-      'YUQUE_PERSONAL_TOKEN or YUQUE_MCP_TEST_TOKEN is required for real API smoke tests'
+      'YUQUE_TOKEN, YUQUE_PERSONAL_TOKEN, or YUQUE_MCP_TEST_TOKEN is required for real API smoke tests'
     );
   }
-  const server = createServer(token, process.env.YUQUE_BASE_URL);
+  const server = createServer(token, baseURL);
   const handler = getRequestHandler<ToolResult>(server, 'tools/call');
   if (!handler) throw new Error('tools/call handler missing');
 

--- a/tests/utils/config.test.ts
+++ b/tests/utils/config.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeYuqueBaseURL, resolveYuqueBaseURL, resolveYuqueToken } from '../../src/config.js';
+
+describe('Yuque runtime config', () => {
+  it('should resolve token with canonical env first and legacy env as fallback', () => {
+    expect(
+      resolveYuqueToken(['node', 'cli.js', '--token=arg-token'], {
+        YUQUE_TOKEN: 'canonical-token',
+        YUQUE_PERSONAL_TOKEN: 'legacy-token',
+      })
+    ).toBe('canonical-token');
+
+    expect(
+      resolveYuqueToken(['node', 'cli.js', '--token=arg-token'], {
+        YUQUE_PERSONAL_TOKEN: 'legacy-token',
+      })
+    ).toBe('legacy-token');
+
+    expect(resolveYuqueToken(['node', 'cli.js', '--token=arg=token'], {})).toBe('arg=token');
+  });
+
+  it('should normalize host values into Yuque API base URLs', () => {
+    expect(normalizeYuqueBaseURL(undefined)).toBeUndefined();
+    expect(normalizeYuqueBaseURL('https://space.yuque.com')).toBe(
+      'https://space.yuque.com/api/v2'
+    );
+    expect(normalizeYuqueBaseURL('https://space.yuque.com/')).toBe(
+      'https://space.yuque.com/api/v2'
+    );
+    expect(normalizeYuqueBaseURL('https://space.yuque.com/api/v2')).toBe(
+      'https://space.yuque.com/api/v2'
+    );
+  });
+
+  it('should resolve host with canonical env and flag before legacy base URL', () => {
+    expect(
+      resolveYuqueBaseURL(['node', 'cli.js', '--host=https://arg.yuque.com'], {
+        YUQUE_HOST: 'https://env.yuque.com',
+        YUQUE_BASE_URL: 'https://legacy.example/api/v2',
+      })
+    ).toBe('https://env.yuque.com/api/v2');
+
+    expect(resolveYuqueBaseURL(['node', 'cli.js', '--host=https://arg.yuque.com'], {})).toBe(
+      'https://arg.yuque.com/api/v2'
+    );
+
+    expect(
+      resolveYuqueBaseURL(['node', 'cli.js', '--base-url=https://legacy.example/api/v2'], {})
+    ).toBe('https://legacy.example/api/v2');
+  });
+});


### PR DESCRIPTION
## Summary
- replace the public MCP server manifest env surface with YUQUE_TOKEN and YUQUE_HOST
- add shared runtime config resolution for canonical token/host plus legacy fallback compatibility
- update install/setup generated configs, docs, and smoke/test coverage for the new contract

## Review
- ReviewAgent Heisenberg (gpt-5.5, xhigh) reviewed the Task 2 diff
- initial P2 request for a server.json manifest contract test was fixed
- final review reported no blocking findings

## Validation
- npm run typecheck
- npm run lint
- npm test
- npm run build
- npm run smoke:dist
- npm run smoke:pack-install
- git diff --check
- rg -n "YUQUE_GROUP_TOKEN" .
