### PR TITLE
[codex] Narrow server tests to wiring

### DIFF
--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -50,68 +50,18 @@ describe('createServer', () => {
     expect(MCP_SERVER_VERSION).toBe(packageJson.version);
   });
 
-  it('should create a server with custom base URL', () => {
-    const server = createServer('test-token', 'https://yuque.internal.com/api/v2');
-    expect(server).toBeDefined();
-  });
-
-  it('should register all 19 tools', async () => {
+  it('should register MCP list and call handlers', async () => {
     const server = createServer('test-token');
     const listToolsHandler = getRequestHandler<{ tools: Array<{ name: string }> }>(
       server,
       'tools/list'
     );
+    const callToolHandler = getRequestHandler(server, 'tools/call');
 
+    expect(listToolsHandler).toEqual(expect.any(Function));
+    expect(callToolHandler).toEqual(expect.any(Function));
     const result = await listToolsHandler?.({ method: 'tools/list', params: {} }, {});
-
-    expect(result?.tools).toHaveLength(19);
-    expect(result?.tools.map((tool) => tool.name)).toEqual(
-      expect.arrayContaining([
-        'yuque_get_resource',
-        'yuque_create_resource',
-        'yuque_update_resource',
-      ])
-    );
-  });
-
-  it('should call a registered tool through the MCP call handler', async () => {
-    const server = createServer('test-token');
-    const mockHttpClient = mockedAxios.create.mock.results[0].value as {
-      get: ReturnType<typeof vi.fn>;
-    };
-    mockHttpClient.get.mockResolvedValue({
-      data: {
-        data: {
-          id: 1,
-          login: 'tester',
-          name: 'Tester',
-          description: 'ok',
-          avatar_url: 'https://example.com/avatar.png',
-          books_count: 2,
-          followers_count: 3,
-        },
-      },
-    });
-
-    const callToolHandler = getRequestHandler<{ content: Array<{ text: string }> }>(
-      server,
-      'tools/call'
-    );
-    const result = await callToolHandler?.(
-      {
-        method: 'tools/call',
-        params: {
-          name: 'yuque_get_user',
-          arguments: {},
-        },
-      },
-      {}
-    );
-
-    expect(JSON.parse(result?.content[0].text ?? '{}')).toMatchObject({
-      id: 1,
-      login: 'tester',
-    });
+    expect(Array.isArray(result?.tools)).toBe(true);
   });
 
   it('should throw for an unknown tool name', async () => {


### PR DESCRIPTION
## Summary
- remove duplicate tool surface and happy-path call assertions from server tests
- keep server tests focused on wiring, error responses, and stdio transport
- rely on MCP contract suites for full tool registry, call-path, and OpenAPI coverage

## Review
- ReviewAgent Linnaeus (gpt-5.5, xhigh) reviewed the Task 4 diff
- final review reported no blocking findings

## Validation
- npm run typecheck
- npm run lint
- npm test
- npm run build
- npm run smoke:dist
- npm run smoke:pack-install
- git diff --check
