### PR TITLE
[codex] remove Claude compatibility pointer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,8 +1,0 @@
-# CLAUDE.md
-
-This repository keeps its canonical agent guidance in `AGENTS.md`.
-
-For Claude Code auto-discovery, use this file as a compatibility pointer:
-
-- Read `AGENTS.md` for repository-specific collaboration and maintenance rules.
-- Start from `docs/README.md` for the project documentation map.


### PR DESCRIPTION
## Summary

- Remove `CLAUDE.md` again after it was reintroduced as a compatibility pointer in #74.
- Keep `AGENTS.md` and `docs/` as the canonical project guidance surface.

## Why

The intended state was to delete `CLAUDE.md` rather than keep a compatibility pointer. The previous PR initially deleted it, but a later commit in the same PR added it back before merge.

## Validation

- `git diff --cached --check -- CLAUDE.md`
- `git diff --name-status origin/main...HEAD` shows only `D CLAUDE.md`.