### PR TITLE
fix: route doc read/write per format and harden transport/tool surface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 pnpm-debug.log*
+
+# Claude Code local state and worktrees
+.claude/

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ MCP server for [Yuque (语雀)](https://www.yuque.com/) — expose your knowledg
 ### 1. Get Your Yuque API Token
 
 Visit [Yuque Developer Settings](https://www.yuque.com/settings/tokens) to create a personal access token.
+If you use a team token from a Yuque space, also prepare that space host, for example `https://your-space.yuque.com`.
 
 ### 2. Quick Install (Recommended)
 
@@ -51,7 +52,7 @@ claude mcp add yuque-mcp -- npx -y yuque-mcp --token=YOUR_TOKEN
 Or using environment variables:
 
 ```bash
-export YUQUE_PERSONAL_TOKEN=YOUR_TOKEN
+export YUQUE_TOKEN=YOUR_TOKEN
 claude mcp add yuque-mcp -- npx -y yuque-mcp
 ```
 
@@ -72,7 +73,7 @@ Add to your `claude_desktop_config.json`:
       "command": "npx",
       "args": ["-y", "yuque-mcp"],
       "env": {
-        "YUQUE_PERSONAL_TOKEN": "YOUR_TOKEN"
+        "YUQUE_TOKEN": "YOUR_TOKEN"
       }
     }
   }
@@ -93,7 +94,7 @@ Add to `.vscode/mcp.json` in your workspace:
       "command": "npx",
       "args": ["-y", "yuque-mcp"],
       "env": {
-        "YUQUE_PERSONAL_TOKEN": "YOUR_TOKEN"
+        "YUQUE_TOKEN": "YOUR_TOKEN"
       }
     }
   }
@@ -116,7 +117,7 @@ Add to your Cursor MCP configuration (`~/.cursor/mcp.json`):
       "command": "npx",
       "args": ["-y", "yuque-mcp"],
       "env": {
-        "YUQUE_PERSONAL_TOKEN": "YOUR_TOKEN"
+        "YUQUE_TOKEN": "YOUR_TOKEN"
       }
     }
   }
@@ -137,7 +138,7 @@ Add to your Windsurf MCP configuration (`~/.windsurf/mcp.json`):
       "command": "npx",
       "args": ["-y", "yuque-mcp"],
       "env": {
-        "YUQUE_PERSONAL_TOKEN": "YOUR_TOKEN"
+        "YUQUE_TOKEN": "YOUR_TOKEN"
       }
     }
   }
@@ -158,7 +159,7 @@ Add to your Cline MCP settings (`~/Library/Application Support/Code/User/globalS
       "command": "npx",
       "args": ["-y", "yuque-mcp"],
       "env": {
-        "YUQUE_PERSONAL_TOKEN": "YOUR_TOKEN"
+        "YUQUE_TOKEN": "YOUR_TOKEN"
       }
     }
   }
@@ -174,13 +175,13 @@ In Trae, open **Settings** and navigate to the **MCP** section, then add a new s
 
 - **Command:** `npx`
 - **Args:** `-y yuque-mcp`
-- **Env:** `YUQUE_PERSONAL_TOKEN=YOUR_TOKEN`
+- **Env:** `YUQUE_TOKEN=YOUR_TOKEN`
 
 See [Trae MCP documentation](https://docs.trae.ai/ide/model-context-protocol) for detailed instructions.
 
 </details>
 
-> **More clients:** Any MCP-compatible client that supports stdio transport can use yuque-mcp. The general pattern is: command = `npx`, args = `["-y", "yuque-mcp"]`, env = `YUQUE_PERSONAL_TOKEN`.
+> **More clients:** Any MCP-compatible client that supports stdio transport can use yuque-mcp. The general pattern is: command = `npx`, args = `["-y", "yuque-mcp"]`, env = `YUQUE_TOKEN`.
 
 </details>
 
@@ -196,27 +197,33 @@ The server supports multiple ways to provide your Yuque API token:
 
 | Method | Environment Variable / Flag | Description |
 |--------|---------------------------|-------------|
-| **Personal Token** (recommended) | `YUQUE_PERSONAL_TOKEN` | For accessing your personal Yuque account |
+| **Token** | `YUQUE_TOKEN` | Personal or team Yuque API token |
+| **Host** | `YUQUE_HOST` / `--host=https://your-space.yuque.com` | Yuque site or space host; required for team tokens tied to a specific space |
 | **CLI Argument** | `--token=YOUR_TOKEN` | Pass directly as a command-line argument |
 
-**Priority order:** `YUQUE_PERSONAL_TOKEN` > `--token`
+**Token priority order:** `YUQUE_TOKEN` > `YUQUE_PERSONAL_TOKEN` > `--token`
 
-### Private Deployment
+**Host priority order:** `YUQUE_HOST` > `--host` > `YUQUE_BASE_URL` > `--base-url`
 
-For privately deployed Yuque instances, set the `YUQUE_BASE_URL` environment variable or use the `--base-url` CLI argument:
+`YUQUE_PERSONAL_TOKEN`, `YUQUE_BASE_URL`, and `--base-url` are kept as legacy fallbacks for existing configs. New configs should use `YUQUE_TOKEN` and `YUQUE_HOST`.
+
+### Team Tokens and Private Deployment
+
+For team tokens, privately deployed Yuque instances, or custom Yuque spaces, set `YUQUE_HOST` or pass `--host`:
 
 ```bash
 # Environment variable
-export YUQUE_BASE_URL=https://yuque.example.com/api/v2
+export YUQUE_TOKEN=YOUR_TOKEN
+export YUQUE_HOST=https://your-space.yuque.com
 
 # CLI argument
-npx yuque-mcp --token=YOUR_TOKEN --base-url=https://yuque.example.com/api/v2
+npx yuque-mcp --token=YOUR_TOKEN --host=https://your-space.yuque.com
 
-# Install with custom base URL
-npx yuque-mcp install --token=YOUR_TOKEN --client=cursor --base-url=https://yuque.example.com/api/v2
+# Install with custom host
+npx yuque-mcp install --token=YOUR_TOKEN --client=cursor --host=https://your-space.yuque.com
 ```
 
-When not set, the default is `https://www.yuque.com/api/v2`.
+The host may be a Yuque site root such as `https://www.yuque.com` or a full API base URL such as `https://www.yuque.com/api/v2`. Host roots are normalized to `/api/v2` at runtime. When not set, the default API base URL is `https://www.yuque.com/api/v2`.
 
 ---
 
@@ -238,7 +245,7 @@ When not set, the default is `https://www.yuque.com/api/v2`.
 
 | Error | Solution |
 |-------|----------|
-| `YUQUE_PERSONAL_TOKEN is required` | Set the environment variable `YUQUE_PERSONAL_TOKEN` or pass `--token=YOUR_TOKEN` |
+| `YUQUE_TOKEN ... is required` | Set `YUQUE_TOKEN=YOUR_TOKEN` or pass `--token=YOUR_TOKEN` |
 | `401 Unauthorized` | Token is invalid or expired — regenerate at [Yuque Settings](https://www.yuque.com/settings/tokens) |
 | `429 Rate Limited` | Too many requests — wait a moment and retry |
 | `410 Gone` | The resource has been permanently deleted or the API endpoint is deprecated — verify the target document/repo still exists |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -14,7 +14,7 @@
 
 ### 1. 获取语雀 API Token
 
-前往 [语雀开发者设置](https://www.yuque.com/settings/tokens) 创建个人访问令牌。
+前往 [语雀开发者设置](https://www.yuque.com/settings/tokens) 创建个人访问令牌。如果使用空间里的团队 Token，也准备对应空间的 host，例如 `https://your-space.yuque.com`。
 
 ### 2. 快速安装（推荐）
 
@@ -24,7 +24,7 @@
 npx yuque-mcp install --token=YOUR_TOKEN --client=cursor
 ```
 
-支持的客户端：`claude-desktop`、`vscode`、`cursor`、`windsurf`、`cline`、`trae`
+支持的客户端：`claude-desktop`、`vscode`、`cursor`、`windsurf`、`cline`、`trae`、`qoder`、`opencode`
 
 或使用交互式安装向导：
 
@@ -51,7 +51,7 @@ claude mcp add yuque-mcp -- npx -y yuque-mcp --token=YOUR_TOKEN
 或使用环境变量：
 
 ```bash
-export YUQUE_PERSONAL_TOKEN=YOUR_TOKEN
+export YUQUE_TOKEN=YOUR_TOKEN
 claude mcp add yuque-mcp -- npx -y yuque-mcp
 ```
 
@@ -72,7 +72,7 @@ claude mcp add yuque-mcp -- npx -y yuque-mcp
       "command": "npx",
       "args": ["-y", "yuque-mcp"],
       "env": {
-        "YUQUE_PERSONAL_TOKEN": "YOUR_TOKEN"
+        "YUQUE_TOKEN": "YOUR_TOKEN"
       }
     }
   }
@@ -93,7 +93,7 @@ claude mcp add yuque-mcp -- npx -y yuque-mcp
       "command": "npx",
       "args": ["-y", "yuque-mcp"],
       "env": {
-        "YUQUE_PERSONAL_TOKEN": "YOUR_TOKEN"
+        "YUQUE_TOKEN": "YOUR_TOKEN"
       }
     }
   }
@@ -116,7 +116,7 @@ claude mcp add yuque-mcp -- npx -y yuque-mcp
       "command": "npx",
       "args": ["-y", "yuque-mcp"],
       "env": {
-        "YUQUE_PERSONAL_TOKEN": "YOUR_TOKEN"
+        "YUQUE_TOKEN": "YOUR_TOKEN"
       }
     }
   }
@@ -137,7 +137,7 @@ claude mcp add yuque-mcp -- npx -y yuque-mcp
       "command": "npx",
       "args": ["-y", "yuque-mcp"],
       "env": {
-        "YUQUE_PERSONAL_TOKEN": "YOUR_TOKEN"
+        "YUQUE_TOKEN": "YOUR_TOKEN"
       }
     }
   }
@@ -158,7 +158,7 @@ claude mcp add yuque-mcp -- npx -y yuque-mcp
       "command": "npx",
       "args": ["-y", "yuque-mcp"],
       "env": {
-        "YUQUE_PERSONAL_TOKEN": "YOUR_TOKEN"
+        "YUQUE_TOKEN": "YOUR_TOKEN"
       }
     }
   }
@@ -174,13 +174,13 @@ claude mcp add yuque-mcp -- npx -y yuque-mcp
 
 - **Command:** `npx`
 - **Args:** `-y yuque-mcp`
-- **Env:** `YUQUE_PERSONAL_TOKEN=YOUR_TOKEN`
+- **Env:** `YUQUE_TOKEN=YOUR_TOKEN`
 
 详见 [Trae MCP 文档](https://docs.trae.ai/ide/model-context-protocol)。
 
 </details>
 
-> **更多客户端：** 任何支持 stdio 传输的 MCP 客户端均可使用 yuque-mcp。通用配置：command = `npx`，args = `["-y", "yuque-mcp"]`，env = `YUQUE_PERSONAL_TOKEN`。
+> **更多客户端：** 任何支持 stdio 传输的 MCP 客户端均可使用 yuque-mcp。通用配置：command = `npx`，args = `["-y", "yuque-mcp"]`，env = `YUQUE_TOKEN`。
 
 </details>
 
@@ -196,27 +196,33 @@ claude mcp add yuque-mcp -- npx -y yuque-mcp
 
 | 方式 | 环境变量 / 参数 | 说明 |
 |------|----------------|------|
-| **个人 Token**（推荐） | `YUQUE_PERSONAL_TOKEN` | 访问个人语雀账号 |
+| **Token** | `YUQUE_TOKEN` | 个人或团队语雀 API Token |
+| **Host** | `YUQUE_HOST` / `--host=https://your-space.yuque.com` | 语雀站点或空间 host；使用绑定空间的团队 Token 时必须设置 |
 | **CLI 参数** | `--token=YOUR_TOKEN` | 通过命令行参数传入 |
 
-**优先级：** `YUQUE_PERSONAL_TOKEN` > `--token`
+**Token 优先级：** `YUQUE_TOKEN` > `YUQUE_PERSONAL_TOKEN` > `--token`
 
-### 私有化部署
+**Host 优先级：** `YUQUE_HOST` > `--host` > `YUQUE_BASE_URL` > `--base-url`
 
-如果使用私有化部署的语雀实例，设置 `YUQUE_BASE_URL` 环境变量或使用 `--base-url` CLI 参数：
+`YUQUE_PERSONAL_TOKEN`、`YUQUE_BASE_URL` 和 `--base-url` 继续作为旧配置的兼容 fallback。新配置建议使用 `YUQUE_TOKEN` 和 `YUQUE_HOST`。
+
+### 团队 Token 与私有化部署
+
+如果使用团队 Token、私有化部署实例或自定义语雀空间，设置 `YUQUE_HOST` 环境变量或使用 `--host` CLI 参数：
 
 ```bash
 # 环境变量
-export YUQUE_BASE_URL=https://yuque.example.com/api/v2
+export YUQUE_TOKEN=YOUR_TOKEN
+export YUQUE_HOST=https://your-space.yuque.com
 
 # CLI 参数
-npx yuque-mcp --token=YOUR_TOKEN --base-url=https://yuque.example.com/api/v2
+npx yuque-mcp --token=YOUR_TOKEN --host=https://your-space.yuque.com
 
 # 安装时指定
-npx yuque-mcp install --token=YOUR_TOKEN --client=cursor --base-url=https://yuque.example.com/api/v2
+npx yuque-mcp install --token=YOUR_TOKEN --client=cursor --host=https://your-space.yuque.com
 ```
 
-不设置时默认为 `https://www.yuque.com/api/v2`。
+`YUQUE_HOST` 可以是语雀站点根地址，例如 `https://www.yuque.com`，也可以是完整 API base URL，例如 `https://www.yuque.com/api/v2`。运行时会把站点根地址规范化到 `/api/v2`。不设置时默认 API base URL 为 `https://www.yuque.com/api/v2`。
 
 ---
 
@@ -238,7 +244,7 @@ npx yuque-mcp install --token=YOUR_TOKEN --client=cursor --base-url=https://yuqu
 
 | 错误 | 解决方案 |
 |------|----------|
-| `YUQUE_PERSONAL_TOKEN is required` | 设置环境变量 `YUQUE_PERSONAL_TOKEN` 或传入 `--token=YOUR_TOKEN` |
+| `YUQUE_TOKEN ... is required` | 设置 `YUQUE_TOKEN=YOUR_TOKEN` 或传入 `--token=YOUR_TOKEN` |
 | `401 Unauthorized` | Token 无效或已过期 — 到[语雀设置](https://www.yuque.com/settings/tokens)重新生成 |
 | `429 Rate Limited` | 请求过于频繁，等待后重试 |
 | 找不到工具 | 更新到最新版本：`npx -y yuque-mcp@latest` |

--- a/docs/capability-scope.md
+++ b/docs/capability-scope.md
@@ -19,13 +19,13 @@
 ## User and Search
 
 - `yuque_get_user`: 读取当前 token 对应的认证用户。
-- `yuque_search`: 搜索语雀内容，`type` 当前限定为 `doc` 或 `repo`。
+- `yuque_search`: 搜索语雀内容，`type` 当前限定为 `doc` 或 `repo`，支持可选 `page` 分页。返回值为精简结构（`total` + `items`），并会剥离语雀搜索结果中的 `<em>` 高亮标签。
 
 ## Books
 
 Books 对应语雀知识库：
 
-- `yuque_list_books`: 按用户 login 列出知识库。
+- `yuque_list_books`: 列出知识库。`login` 可选，省略时自动取当前认证用户；支持可选 `offset` / `limit` 分页。
 - `yuque_get_book`: 按 repo ID 或 namespace 读取知识库。
 - `yuque_create_book`: 在指定用户下创建知识库。
 - `yuque_update_book`: 更新知识库名称、slug、描述或公开状态。
@@ -34,18 +34,18 @@ Books 对应语雀知识库：
 
 Docs 对应语雀文档：
 
-- `yuque_list_docs`: 列出知识库下的文档。
+- `yuque_list_docs`: 列出知识库下的文档，支持可选 `offset` / `limit` 分页（API 单页上限 100）。
 - `yuque_get_doc`: 读取文档完整内容。
 - `yuque_create_doc`: 创建文档；TOC 追加行为由当前工具 contract 控制，需要稳定目录位置时可用 TOC tools 读取或调整。
 - `yuque_update_doc`: 更新文档元数据或内容。
 
-文档 format（格式）当前限定为：
+文档 format（格式）当前限定为 `markdown` / `lake` / `html`，并按 format 二选一路由，单次调用只走一条语雀 API 链路：
 
-- `markdown`: 默认路径，读写走 YMD/YFM-compatible API。
-- `lake`: 走 legacy document API。
-- `html`: 走 legacy document API。
+- `yuque_get_doc`: format 省略或 `markdown` 时只走 YMD markdown API，返回 YMD 视图（`id`、`title`、`url`、`format`、`body`、`updated_at`）；format 为 `lake` / `html` 或 `include_lake: true` 时只走 legacy document API，返回完整文档字段。
+- `yuque_update_doc`: markdown body 只走 YMD markdown API，且不能与 `title` / `slug` / `public` 混在同一次调用（会显式报错，提示分两次调用）；纯元数据更新或 `lake` / `html` body 只走 legacy document API。
+- YMD API 只接受数字 doc ID；传 slug 时会先做一次 ID 解析调用，传数字 ID 可省掉这次调用。
 
-`yuque_get_doc` 还支持 `include_lake`，用于在需要保留 Mermaid source、diagram 等 Lake 内容时返回 raw Lake body。
+`yuque_get_doc` 还支持 `include_lake`，用于在需要保留 Mermaid source、diagram 等 Lake 内容时返回 raw Lake body（强制走 legacy 路径）。
 
 ## TOC
 

--- a/docs/core-architecture.md
+++ b/docs/core-architecture.md
@@ -18,9 +18,10 @@ MCP client
 
 ## Entry Points
 
-- `src/cli.ts`: npm bin 入口，读取 `YUQUE_PERSONAL_TOKEN` / `--token` 和可选 `YUQUE_BASE_URL` / `--base-url`，默认以 stdio transport 启动 MCP server。直接在终端运行时会打印安装指引，避免用户误以为服务卡住。
-- `src/index.ts`: HTTP 入口，读取同一组 token / base URL 配置，使用 `StreamableHTTPServerTransport` 并监听 `PORT`，默认 `3000`。
+- `src/cli.ts`: npm bin 入口，通过 `src/config.ts` 解析 token 和 base URL，默认以 stdio transport 启动 MCP server。直接在终端运行时会打印安装指引，避免用户误以为服务卡住。
+- `src/index.ts`: HTTP 入口，读取同一组 token / base URL 配置，使用 `StreamableHTTPServerTransport` 并监听 `PORT`（默认 `3000`）。每个 MCP session 对应一对独立的 transport + server 实例（initialize 时创建，session 关闭时清理）；默认只绑定 `127.0.0.1` 并开启 DNS rebinding 防护，设置 `HOST` 环境变量可显式暴露到其他网卡（此时防护关闭，需自行加防护层）。
 - `src/cli-install.ts`: CLI 子命令入口，负责 `install` 和 `setup`，把 `yuque-mcp` 写入不同 MCP client 的配置文件。
+- `src/config.ts`: 统一的 token / host 解析逻辑，被 CLI 和 HTTP 入口共用。
 
 ## MCP Server Layer
 
@@ -58,10 +59,15 @@ MCP client
 
 ## Document Content Path
 
-文档内容有两条路径：
+文档内容有两条路径，按 format 二选一路由，单次工具调用只走其中一条：
 
-- `markdown` 或未显式指定 format 时，读写走 YMD/YFM-compatible API：`/yfm/docs`。
-- `lake` / `html` 时，走 legacy document API：`/repos/{repo}/docs/{doc}`。
+- `markdown` 或未显式指定 format 时，读写只走 YMD/YFM-compatible API：`/yfm/docs`。
+- `lake` / `html`（以及 `include_lake: true` 的读取）时，只走 legacy document API：`/repos/{repo}/docs/{doc}`。
+
+补充约束：
+
+- YMD API 只接受数字 doc ID，传 slug 时会先经 legacy API 解析出 ID。
+- markdown body 更新不与 title/slug/public 元数据混在同一次调用；混合传参会显式报错，引导分两次调用，避免跨两条链路的部分更新。
 
 这个设计把用户常用的 Markdown 体验放在 YMD/YFM flow 上，同时保留 Lake/HTML 的兼容路径。
 

--- a/docs/technical-stack.md
+++ b/docs/technical-stack.md
@@ -18,13 +18,18 @@
 
 ## Configuration and Authentication
 
-当前运行时配置在 CLI / HTTP 入口解析，然后传给 server 和 `YuqueClient`：
+当前运行时配置由 `src/config.ts` 统一解析（CLI 和 HTTP 入口共用），然后传给 server 和 `YuqueClient`：
 
-- Token 读取优先级：`YUQUE_PERSONAL_TOKEN` -> `--token`。
-- Base URL 读取优先级：`YUQUE_BASE_URL` -> `--base-url`。
-- `--base-url` 需要传完整 API base URL，例如 `https://yuque.example.com/api/v2`。
+- Token 读取优先级：`YUQUE_TOKEN` -> `YUQUE_PERSONAL_TOKEN` -> `--token`。
+- Host / Base URL 读取优先级：`YUQUE_HOST` -> `--host` -> `YUQUE_BASE_URL` -> `--base-url`。
+- `YUQUE_HOST` / `--host` 传站点或空间地址（如 `https://your-space.yuque.com`），会自动补全 `/api/v2`；`YUQUE_BASE_URL` / `--base-url` 传完整 API base URL。
 - 默认语雀 API base URL 由 `YuqueClient` 提供：`https://www.yuque.com/api/v2`。
 - 请求认证 header 为 `X-Auth-Token`。
+
+HTTP 入口（`src/index.ts`）额外支持：
+
+- `PORT`: 监听端口，默认 `3000`。
+- `HOST`: 绑定地址，默认 `127.0.0.1`（回环）。默认开启 DNS rebinding 防护（校验 Host header）；显式设置为非回环地址时防护关闭，网络暴露需自行加认证层。
 
 ## Development Tooling
 

--- a/scripts/cli-smoke-utils.js
+++ b/scripts/cli-smoke-utils.js
@@ -4,7 +4,7 @@ import path from 'node:path';
 import process from 'node:process';
 
 export const EXPECTED_MISSING_TOKEN_MESSAGE =
-  'Error: YUQUE_PERSONAL_TOKEN environment variable or --token argument is required';
+  'Error: YUQUE_TOKEN environment variable, YUQUE_PERSONAL_TOKEN environment variable, or --token argument is required';
 
 const DEFAULT_TIMEOUT_MS = 5000;
 
@@ -23,6 +23,7 @@ export async function assertCliStartsAndFailsWithoutToken(
     cwd,
     env: {
       ...process.env,
+      YUQUE_TOKEN: '',
       YUQUE_PERSONAL_TOKEN: '',
     },
     stdio: [ 'pipe', 'pipe', 'pipe' ],

--- a/server.json
+++ b/server.json
@@ -6,35 +6,28 @@
     "url": "https://github.com/yuque/yuque-mcp-server",
     "source": "github"
   },
-  "version": "0.1.4",
+  "version": "1.0.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "yuque-mcp",
-      "version": "0.1.4",
+      "version": "1.0.0",
       "transport": {
         "type": "stdio"
       },
       "environmentVariables": [
         {
-          "name": "YUQUE_PERSONAL_TOKEN",
-          "description": "Yuque personal API token (get from https://www.yuque.com/settings/tokens). Use one of: YUQUE_PERSONAL_TOKEN, YUQUE_GROUP_TOKEN, or YUQUE_TOKEN.",
-          "isRequired": false,
-          "isSecret": true,
-          "format": "string"
-        },
-        {
-          "name": "YUQUE_GROUP_TOKEN",
-          "description": "Yuque group/team API token (alternative to YUQUE_PERSONAL_TOKEN for team workspaces).",
-          "isRequired": false,
-          "isSecret": true,
-          "format": "string"
-        },
-        {
           "name": "YUQUE_TOKEN",
-          "description": "Yuque API token (legacy, use YUQUE_PERSONAL_TOKEN or YUQUE_GROUP_TOKEN instead).",
-          "isRequired": false,
+          "description": "Yuque API token. Use a personal token for your account, or a team token together with YUQUE_HOST for the matching Yuque space.",
+          "isRequired": true,
           "isSecret": true,
+          "format": "string"
+        },
+        {
+          "name": "YUQUE_HOST",
+          "description": "Yuque site or space host, for example https://www.yuque.com or https://your-space.yuque.com. Required when using a team token from a specific space.",
+          "isRequired": false,
+          "isSecret": false,
           "format": "string"
         }
       ]

--- a/src/cli-install.ts
+++ b/src/cli-install.ts
@@ -20,7 +20,7 @@ interface ClientConfig {
   configKey: 'mcpServers' | 'servers' | 'mcp';
   getConfigPath: () => string;
   /** Custom function to build the server entry for this client (if different from the default). */
-  buildEntry?: (token: string, baseURL?: string) => Record<string, unknown>;
+  buildEntry?: (token: string, host?: string) => Record<string, unknown>;
 }
 
 function getAppDataPath(): string {
@@ -173,9 +173,8 @@ const CLIENT_CONFIGS: Record<ClientId, ClientConfig> = {
     getConfigPath() {
       return path.join(process.cwd(), 'opencode.json');
     },
-    buildEntry(token: string, baseURL?: string) {
-      const env: Record<string, string> = { YUQUE_PERSONAL_TOKEN: token };
-      if (baseURL) env.YUQUE_BASE_URL = baseURL;
+    buildEntry(token: string, host?: string) {
+      const env = buildMcpEnv(token, host);
       return {
         type: 'local',
         command: ['npx', '-y', 'yuque-mcp'],
@@ -188,13 +187,17 @@ const CLIENT_CONFIGS: Record<ClientId, ClientConfig> = {
 
 // ─── Config Generation ────────────────────────────────────────────────
 
-function buildServerEntry(token: string, baseURL?: string) {
-  const env: Record<string, string> = { YUQUE_PERSONAL_TOKEN: token };
-  if (baseURL) env.YUQUE_BASE_URL = baseURL;
+function buildMcpEnv(token: string, host?: string): Record<string, string> {
+  const env: Record<string, string> = { YUQUE_TOKEN: token };
+  if (host) env.YUQUE_HOST = host;
+  return env;
+}
+
+function buildServerEntry(token: string, host?: string) {
   return {
     command: 'npx',
     args: ['-y', 'yuque-mcp'],
-    env,
+    env: buildMcpEnv(token, host),
   };
 }
 
@@ -203,6 +206,8 @@ function buildServerEntry(token: string, baseURL?: string) {
 export interface InstallOptions {
   token: string;
   client: ClientId;
+  host?: string;
+  /** @deprecated Use host. Kept so older callers can still generate config. */
   baseURL?: string;
 }
 
@@ -251,9 +256,10 @@ export function installToClient(options: InstallOptions): string {
 
   // Inject/update the yuque entry
   const serversObj = config[configKey] as Record<string, unknown>;
+  const host = options.host ?? options.baseURL;
   serversObj['yuque'] = clientConfig.buildEntry
-    ? clientConfig.buildEntry(options.token, options.baseURL)
-    : buildServerEntry(options.token, options.baseURL);
+    ? clientConfig.buildEntry(options.token, host)
+    : buildServerEntry(options.token, host);
 
   // Create parent directories if needed
   const dir = path.dirname(configPath);
@@ -270,29 +276,26 @@ export function installToClient(options: InstallOptions): string {
 export function runInstall(args: string[]): void {
   const tokenArg = args.find((a) => a.startsWith('--token='));
   const clientArg = args.find((a) => a.startsWith('--client='));
+  const hostArg = args.find((a) => a.startsWith('--host='));
   const baseURLArg = args.find((a) => a.startsWith('--base-url='));
 
   if (!tokenArg) {
     console.error('Error: --token=YOUR_TOKEN is required.');
-    console.error(
-      'Usage: npx yuque-mcp install --token=YOUR_TOKEN --client=CLIENT [--base-url=URL]'
-    );
+    console.error('Usage: npx yuque-mcp install --token=YOUR_TOKEN --client=CLIENT [--host=HOST]');
     console.error(`Supported clients: ${getSupportedClients().join(', ')}`);
     process.exit(1);
   }
 
   if (!clientArg) {
     console.error('Error: --client=CLIENT is required.');
-    console.error(
-      'Usage: npx yuque-mcp install --token=YOUR_TOKEN --client=CLIENT [--base-url=URL]'
-    );
+    console.error('Usage: npx yuque-mcp install --token=YOUR_TOKEN --client=CLIENT [--host=HOST]');
     console.error(`Supported clients: ${getSupportedClients().join(', ')}`);
     process.exit(1);
   }
 
   const token = tokenArg.split('=').slice(1).join('=');
   const client = clientArg.split('=').slice(1).join('=') as ClientId;
-  const baseURL = baseURLArg?.split('=').slice(1).join('=');
+  const host = hostArg?.split('=').slice(1).join('=') ?? baseURLArg?.split('=').slice(1).join('=');
 
   if (!token) {
     console.error('Error: Token value cannot be empty.');
@@ -300,7 +303,7 @@ export function runInstall(args: string[]): void {
   }
 
   try {
-    const configPath = installToClient({ token, client, baseURL });
+    const configPath = installToClient({ token, client, host });
     const clientName = CLIENT_CONFIGS[client]?.name ?? client;
     console.log(`\n✅ Successfully configured yuque-mcp for ${clientName}!`);
     console.log(`   Config file: ${configPath}`);
@@ -361,14 +364,14 @@ export async function runSetup(): Promise<void> {
 
     const client = clients[idx];
 
-    // Step 3: Ask for base URL (optional, for private deployments)
-    console.log('\nStep 3: Enter your Yuque API base URL (optional)');
-    console.log('   (Leave empty for https://www.yuque.com/api/v2)\n');
-    const baseURL = (await askQuestion(rl, '   Base URL: ')) || undefined;
+    // Step 3: Ask for host (optional, for team tokens or private deployments)
+    console.log('\nStep 3: Enter your Yuque host (optional)');
+    console.log('   (Leave empty for https://www.yuque.com)\n');
+    const host = (await askQuestion(rl, '   Host: ')) || undefined;
 
     // Step 4: Install
     console.log('');
-    const configPath = installToClient({ token, client, baseURL });
+    const configPath = installToClient({ token, client, host });
     const clientName = CLIENT_CONFIGS[client].name;
     console.log(`✅ Successfully configured yuque-mcp for ${clientName}!`);
     console.log(`   Config file: ${configPath}`);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import { createRequire } from 'node:module';
 import { handleCliSubcommands } from './cli-install.js';
+import { MISSING_TOKEN_MESSAGE, resolveYuqueBaseURL, resolveYuqueToken } from './config.js';
 import { runStdioServer } from './server.js';
 
 // Handle install/setup subcommands before starting the MCP server
@@ -9,14 +10,10 @@ if (handleCliSubcommands(process.argv)) {
   // For async subcommands (setup), the process will exit when done.
 } else {
   // Normal MCP server startup
-  const token =
-    process.env.YUQUE_PERSONAL_TOKEN ||
-    process.argv.find((arg) => arg.startsWith('--token='))?.split('=')[1];
+  const token = resolveYuqueToken();
 
   if (!token) {
-    console.error(
-      'Error: YUQUE_PERSONAL_TOKEN environment variable or --token argument is required'
-    );
+    console.error(MISSING_TOKEN_MESSAGE);
     process.exit(1);
   }
 
@@ -48,9 +45,7 @@ if (handleCliSubcommands(process.argv)) {
     process.exit(0);
   }
 
-  const baseURL =
-    process.env.YUQUE_BASE_URL ||
-    process.argv.find((arg) => arg.startsWith('--base-url='))?.split('=')[1];
+  const baseURL = resolveYuqueBaseURL();
 
   runStdioServer(token, baseURL).catch((error) => {
     console.error('Fatal error:', error);

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,46 @@
+export const MISSING_TOKEN_MESSAGE =
+  'Error: YUQUE_TOKEN environment variable, YUQUE_PERSONAL_TOKEN environment variable, or --token argument is required';
+
+function readArg(argv: string[], name: string): string | undefined {
+  return argv
+    .find((arg) => arg.startsWith(`--${name}=`))
+    ?.split('=')
+    .slice(1)
+    .join('=');
+}
+
+export function normalizeYuqueBaseURL(value: string | undefined): string | undefined {
+  const raw = value?.trim();
+  if (!raw) return undefined;
+
+  const withoutTrailingSlash = raw.replace(/\/+$/, '');
+
+  try {
+    const url = new URL(withoutTrailingSlash);
+    const pathname = url.pathname.replace(/\/+$/, '');
+    if (!pathname || pathname === '/') {
+      url.pathname = '/api/v2';
+      return url.toString().replace(/\/+$/, '');
+    }
+    return withoutTrailingSlash;
+  } catch {
+    return withoutTrailingSlash;
+  }
+}
+
+export function resolveYuqueToken(
+  argv: string[] = process.argv,
+  env: NodeJS.ProcessEnv = process.env
+): string | undefined {
+  return env.YUQUE_TOKEN || env.YUQUE_PERSONAL_TOKEN || readArg(argv, 'token');
+}
+
+export function resolveYuqueBaseURL(
+  argv: string[] = process.argv,
+  env: NodeJS.ProcessEnv = process.env
+): string | undefined {
+  const hostOrBaseURL =
+    env.YUQUE_HOST || readArg(argv, 'host') || env.YUQUE_BASE_URL || readArg(argv, 'base-url');
+
+  return normalizeYuqueBaseURL(hostOrBaseURL);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,43 +1,101 @@
 import { createServer as createMCPServer } from './server.js';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
-import { createServer } from 'node:http';
+import { isInitializeRequest } from '@modelcontextprotocol/sdk/types.js';
+import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
 import { randomUUID } from 'node:crypto';
+import { MISSING_TOKEN_MESSAGE, resolveYuqueBaseURL, resolveYuqueToken } from './config.js';
 
-const token =
-  process.env.YUQUE_PERSONAL_TOKEN ||
-  process.argv.find((arg) => arg.startsWith('--token='))?.split('=')[1];
+const resolvedToken = resolveYuqueToken();
 
-if (!token) {
-  console.error('Error: YUQUE_PERSONAL_TOKEN environment variable or --token argument is required');
+if (!resolvedToken) {
+  console.error(MISSING_TOKEN_MESSAGE);
   process.exit(1);
 }
 
-const baseURL =
-  process.env.YUQUE_BASE_URL ||
-  process.argv.find((arg) => arg.startsWith('--base-url='))?.split('=')[1];
+// Re-bind after the guard so hoisted functions see a plain string type.
+const token: string = resolvedToken;
 
-const mcpServer = createMCPServer(token, baseURL);
-const transport = new StreamableHTTPServerTransport({
-  sessionIdGenerator: () => randomUUID(),
+const baseURL = resolveYuqueBaseURL();
+const port = Number(process.env.PORT) || 3000;
+// Bind to loopback by default; set HOST explicitly to expose the server on other interfaces.
+const host = process.env.HOST || '127.0.0.1';
+const isLoopback = host === '127.0.0.1' || host === 'localhost' || host === '::1';
+
+// A stateful StreamableHTTPServerTransport serves exactly one MCP session,
+// so each session gets its own transport + MCP server pair.
+const transports = new Map<string, StreamableHTTPServerTransport>();
+
+async function readJsonBody(req: IncomingMessage): Promise<unknown> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of req) {
+    chunks.push(typeof chunk === 'string' ? Buffer.from(chunk) : chunk);
+  }
+  const raw = Buffer.concat(chunks).toString('utf-8');
+  return raw ? JSON.parse(raw) : undefined;
+}
+
+function sendJsonRpcError(res: ServerResponse, status: number, code: number, message: string) {
+  res.writeHead(status, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify({ jsonrpc: '2.0', error: { code, message }, id: null }));
+}
+
+async function handleHttpRequest(req: IncomingMessage, res: ServerResponse) {
+  const sessionId = req.headers['mcp-session-id'];
+
+  if (typeof sessionId === 'string') {
+    const transport = transports.get(sessionId);
+    if (!transport) {
+      sendJsonRpcError(res, 404, -32001, 'Session not found');
+      return;
+    }
+    await transport.handleRequest(req, res);
+    return;
+  }
+
+  if (req.method !== 'POST') {
+    sendJsonRpcError(res, 400, -32000, 'Bad Request: Mcp-Session-Id header is required');
+    return;
+  }
+
+  const body = await readJsonBody(req);
+  if (!isInitializeRequest(body)) {
+    sendJsonRpcError(res, 400, -32000, 'Bad Request: expected an initialize request');
+    return;
+  }
+
+  const transport = new StreamableHTTPServerTransport({
+    sessionIdGenerator: () => randomUUID(),
+    // Validate the Host header on local deployments so malicious web pages
+    // cannot reach the server through DNS rebinding.
+    enableDnsRebindingProtection: isLoopback,
+    allowedHosts: isLoopback
+      ? ['127.0.0.1', `127.0.0.1:${port}`, 'localhost', `localhost:${port}`]
+      : undefined,
+    onsessioninitialized: (sid) => {
+      transports.set(sid, transport);
+    },
+  });
+  transport.onclose = () => {
+    if (transport.sessionId) {
+      transports.delete(transport.sessionId);
+    }
+  };
+
+  const mcpServer = createMCPServer(token, baseURL);
+  await mcpServer.connect(transport);
+  await transport.handleRequest(req, res, body);
+}
+
+const httpServer = createServer((req, res) => {
+  handleHttpRequest(req, res).catch((error) => {
+    console.error('Request handling error:', error);
+    if (!res.headersSent) {
+      res.statusCode = 500;
+      res.end('Internal Server Error');
+    }
+  });
 });
 
-mcpServer
-  .connect(transport)
-  .then(() => {
-    const port = Number(process.env.PORT) || 3000;
-    const httpServer = createServer((req, res) => {
-      transport.handleRequest(req, res).catch((error) => {
-        console.error('Request handling error:', error);
-        res.statusCode = 500;
-        res.end('Internal Server Error');
-      });
-    });
-
-    httpServer.listen(port, () => {
-      console.log(`Yuque MCP Server running on http://localhost:${port}`);
-    });
-  })
-  .catch((error) => {
-    console.error('Failed to start server:', error);
-    process.exit(1);
-  });
+httpServer.listen(port, host, () => {
+  console.log(`Yuque MCP Server running on http://${host}:${port}`);
+});

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -15,19 +15,6 @@ export interface YuqueUser {
   updated_at: string;
 }
 
-export interface YuqueGroup {
-  id: number;
-  login: string;
-  name: string;
-  description: string;
-  avatar_url: string;
-  books_count: number;
-  public_books_count: number;
-  members_count: number;
-  created_at: string;
-  updated_at: string;
-}
-
 export interface YuqueRepo {
   id: number;
   type: string;
@@ -178,36 +165,6 @@ export interface YuqueSearchResult {
   total: number;
 }
 
-export interface YuqueDocVersion {
-  id: number;
-  doc_id: number;
-  title: string;
-  body: string;
-  body_draft: string;
-  format: string;
-  user_id: number;
-  user?: YuqueUser;
-  created_at: string;
-}
-
-export interface YuqueGroupMember {
-  id: number;
-  group_id: number;
-  user_id: number;
-  user?: YuqueUser;
-  role: number;
-  created_at: string;
-  updated_at: string;
-}
-
-export interface YuqueStatistics {
-  books_count: number;
-  docs_count: number;
-  members_count: number;
-  public_books_count: number;
-  public_docs_count: number;
-}
-
 export interface YuqueApiResponse<T> {
   data: T;
 }
@@ -251,7 +208,6 @@ export interface UpdateDocData {
   format?: string;
   public?: number;
 }
-// 添加到 src/services/types.ts 的小记类型定义
 
 export interface YuqueNoteContent {
   updated_at: string;

--- a/src/services/yuque-client.ts
+++ b/src/services/yuque-client.ts
@@ -1,16 +1,12 @@
 import axios, { type AxiosInstance } from 'axios';
 import type {
   YuqueUser,
-  YuqueGroup,
   YuqueRepo,
   YuqueDoc,
   YuqueYmdDoc,
   YuqueYmdDocWriteResult,
   YuqueTocItem,
   YuqueSearchResult,
-  YuqueDocVersion,
-  YuqueGroupMember,
-  YuqueStatistics,
   YuqueApiResponse,
   CreateRepoData,
   UpdateRepoData,
@@ -83,21 +79,14 @@ export class YuqueClient {
     });
   }
 
-  /** List groups/teams that a user belongs to. */
-  async listGroups(userId: number): Promise<YuqueGroup[]> {
-    return withErrorHandling(async () => {
-      const r = await this.client.get<YuqueApiResponse<YuqueGroup[]>>(`/users/${userId}/groups`);
-      return r.data.data;
-    });
-  }
-
   // ── Search API ─────────────────────────────────────────────
 
   /** Search for documents, repos, or users. */
-  async search(query: string, type?: string): Promise<YuqueSearchResult> {
+  async search(query: string, type?: string, page?: number): Promise<YuqueSearchResult> {
     return withErrorHandling(async () => {
-      const params: { q: string; type?: string } = { q: query };
+      const params: { q: string; type?: string; page?: number } = { q: query };
       if (type) params.type = type;
+      if (page !== undefined) params.page = page;
       const r = await this.client.get<YuqueApiResponse<YuqueSearchResult>>('/search', { params });
       return r.data.data;
     });
@@ -105,18 +94,18 @@ export class YuqueClient {
 
   // ── Repo APIs ──────────────────────────────────────────────
 
-  /** List all repos for a user. */
-  async listUserRepos(login: string): Promise<YuqueRepo[]> {
+  /** List repos for a user with optional pagination. */
+  async listUserRepos(
+    login: string,
+    options?: { offset?: number; limit?: number }
+  ): Promise<YuqueRepo[]> {
     return withErrorHandling(async () => {
-      const r = await this.client.get<YuqueApiResponse<YuqueRepo[]>>(`/users/${login}/repos`);
-      return r.data.data;
-    });
-  }
-
-  /** List all repos for a group. */
-  async listGroupRepos(login: string): Promise<YuqueRepo[]> {
-    return withErrorHandling(async () => {
-      const r = await this.client.get<YuqueApiResponse<YuqueRepo[]>>(`/groups/${login}/repos`);
+      const params: Record<string, number> = {};
+      if (options?.offset !== undefined) params.offset = options.offset;
+      if (options?.limit !== undefined) params.limit = options.limit;
+      const r = await this.client.get<YuqueApiResponse<YuqueRepo[]>>(`/users/${login}/repos`, {
+        params,
+      });
       return r.data.data;
     });
   }
@@ -137,14 +126,6 @@ export class YuqueClient {
     });
   }
 
-  /** Create a new repo under a group. */
-  async createGroupRepo(login: string, data: CreateRepoData): Promise<YuqueRepo> {
-    return withErrorHandling(async () => {
-      const r = await this.client.post<YuqueApiResponse<YuqueRepo>>(`/groups/${login}/repos`, data);
-      return r.data.data;
-    });
-  }
-
   /** Update a repo by ID or namespace. */
   async updateRepo(idOrNamespace: string | number, data: UpdateRepoData): Promise<YuqueRepo> {
     return withErrorHandling(async () => {
@@ -153,19 +134,20 @@ export class YuqueClient {
     });
   }
 
-  /** Delete a repo by ID or namespace. */
-  async deleteRepo(idOrNamespace: string | number): Promise<void> {
-    return withErrorHandling(async () => {
-      await this.client.delete(`/repos/${idOrNamespace}`);
-    });
-  }
-
   // ── Doc APIs ───────────────────────────────────────────────
 
-  /** List all documents in a repo. */
-  async listDocs(repoId: string | number): Promise<YuqueDoc[]> {
+  /** List documents in a repo with optional pagination (the API caps limit at 100). */
+  async listDocs(
+    repoId: string | number,
+    options?: { offset?: number; limit?: number }
+  ): Promise<YuqueDoc[]> {
     return withErrorHandling(async () => {
-      const r = await this.client.get<YuqueApiResponse<YuqueDoc[]>>(`/repos/${repoId}/docs`);
+      const params: Record<string, number> = {};
+      if (options?.offset !== undefined) params.offset = options.offset;
+      if (options?.limit !== undefined) params.limit = options.limit;
+      const r = await this.client.get<YuqueApiResponse<YuqueDoc[]>>(`/repos/${repoId}/docs`, {
+        params,
+      });
       return r.data.data;
     });
   }
@@ -254,13 +236,6 @@ export class YuqueClient {
     });
   }
 
-  /** Delete a document. */
-  async deleteDoc(repoId: string | number, docId: string | number): Promise<void> {
-    return withErrorHandling(async () => {
-      await this.client.delete(`/repos/${repoId}/docs/${docId}`);
-    });
-  }
-
   // ── TOC APIs ───────────────────────────────────────────────
 
   /** Get the table of contents for a repo. */
@@ -278,114 +253,6 @@ export class YuqueClient {
         `/repos/${repoId}/toc`,
         data
       );
-      return r.data.data;
-    });
-  }
-
-  // ── Doc Version APIs ───────────────────────────────────────
-
-  /** List all versions of a document. */
-  async listDocVersions(docId: number): Promise<YuqueDocVersion[]> {
-    return withErrorHandling(async () => {
-      const r = await this.client.get<YuqueApiResponse<YuqueDocVersion[]>>('/doc_versions', {
-        params: { doc_id: docId },
-      });
-      return r.data.data;
-    });
-  }
-
-  /** Get a specific version of a document. */
-  async getDocVersion(versionId: number): Promise<YuqueDocVersion> {
-    return withErrorHandling(async () => {
-      const r = await this.client.get<YuqueApiResponse<YuqueDocVersion>>(
-        `/doc_versions/${versionId}`
-      );
-      return r.data.data;
-    });
-  }
-
-  // ── Group Member APIs ──────────────────────────────────────
-
-  /** List all members of a group. */
-  async listGroupMembers(login: string): Promise<YuqueGroupMember[]> {
-    return withErrorHandling(async () => {
-      const r = await this.client.get<YuqueApiResponse<YuqueGroupMember[]>>(
-        `/groups/${login}/users`
-      );
-      return r.data.data;
-    });
-  }
-
-  /** Update a group member's role. */
-  async updateGroupMember(
-    login: string,
-    userId: number,
-    data: { role: number }
-  ): Promise<YuqueGroupMember> {
-    return withErrorHandling(async () => {
-      const r = await this.client.put<YuqueApiResponse<YuqueGroupMember>>(
-        `/groups/${login}/users/${userId}`,
-        data
-      );
-      return r.data.data;
-    });
-  }
-
-  /** Remove a member from a group. */
-  async removeGroupMember(login: string, userId: number): Promise<void> {
-    return withErrorHandling(async () => {
-      await this.client.delete(`/groups/${login}/users/${userId}`);
-    });
-  }
-
-  // ── Statistics APIs ────────────────────────────────────────
-
-  /** Get overall statistics for a group. */
-  async getGroupStats(login: string): Promise<YuqueStatistics> {
-    return withErrorHandling(async () => {
-      const r = await this.client.get<YuqueApiResponse<YuqueStatistics>>(
-        `/groups/${login}/statistics`
-      );
-      return r.data.data;
-    });
-  }
-
-  /** Get member statistics for a group. */
-  async getGroupMemberStats(login: string): Promise<unknown> {
-    return withErrorHandling(async () => {
-      const r = await this.client.get<YuqueApiResponse<unknown>>(
-        `/groups/${login}/statistics/members`
-      );
-      return r.data.data;
-    });
-  }
-
-  /** Get book/repo statistics for a group. */
-  async getGroupBookStats(login: string): Promise<unknown> {
-    return withErrorHandling(async () => {
-      const r = await this.client.get<YuqueApiResponse<unknown>>(
-        `/groups/${login}/statistics/books`
-      );
-      return r.data.data;
-    });
-  }
-
-  /** Get document statistics for a group. */
-  async getGroupDocStats(login: string): Promise<unknown> {
-    return withErrorHandling(async () => {
-      const r = await this.client.get<YuqueApiResponse<unknown>>(
-        `/groups/${login}/statistics/docs`
-      );
-      return r.data.data;
-    });
-  }
-
-  // ── Hello API ──────────────────────────────────────────────
-
-  /** Test API connectivity. */
-  async hello(): Promise<{ message: string }> {
-    return withErrorHandling(async () => {
-      const r = await this.client.get<YuqueApiResponse<{ message: string }>>('/hello');
       return r.data.data;
     });
   }
@@ -426,34 +293,10 @@ export class YuqueClient {
   /** Update an existing note. */
   async updateNote(noteId: number, data: UpdateNoteData): Promise<YuqueNote> {
     return withErrorHandling(async () => {
+      // Unlike other endpoints, PUT /notes/:id wraps the note in an extra
+      // envelope: the HTTP body is { data: { data: <note> } }.
       const r = await this.client.put<{ data: { data: YuqueNote } }>(`/notes/${noteId}`, data);
       return r.data.data.data;
-    });
-  }
-
-  /** Delete a note (move to trash). */
-  async deleteNote(noteId: number): Promise<void> {
-    return withErrorHandling(async () => {
-      const note = await this.getNote(noteId);
-      await this.updateNote(noteId, {
-        source: note.content.source || '',
-        html: note.content.html || '',
-        abstract: note.content.abstract || '',
-        status: 9,
-      });
-    });
-  }
-
-  /** Restore a note from trash. */
-  async restoreNote(noteId: number): Promise<void> {
-    return withErrorHandling(async () => {
-      const note = await this.getNote(noteId);
-      await this.updateNote(noteId, {
-        source: note.content.source || '',
-        html: note.content.html || '',
-        abstract: note.content.abstract || '',
-        status: 0,
-      });
     });
   }
 }

--- a/src/tools/book.ts
+++ b/src/tools/book.ts
@@ -4,12 +4,29 @@ import { formatRepo } from '../utils/format.js';
 
 export const bookTools = {
   yuque_list_books: {
-    description: 'List all books (知识库) for the current user',
+    description: 'List books (知识库) for a user (defaults to the current user)',
     inputSchema: z.object({
-      login: z.string().describe('User login name'),
+      login: z
+        .string()
+        .optional()
+        .describe('User login name. Omit to list books for the current authenticated user.'),
+      offset: z
+        .number()
+        .int()
+        .min(0)
+        .optional()
+        .describe('Pagination offset (number of books to skip)'),
+      limit: z.number().int().min(1).max(100).optional().describe('Number of books per page'),
     }),
-    handler: async (client: YuqueClient, args: { login: string }) => {
-      const repos = await client.listUserRepos(args.login);
+    handler: async (
+      client: YuqueClient,
+      args: { login?: string; offset?: number; limit?: number }
+    ) => {
+      const login = args.login ?? (await client.getUser()).login;
+      const repos = await client.listUserRepos(login, {
+        offset: args.offset,
+        limit: args.limit,
+      });
       return {
         content: [
           {

--- a/src/tools/doc.ts
+++ b/src/tools/doc.ts
@@ -1,7 +1,11 @@
 import { z } from 'zod';
 import type { YuqueClient } from '../services/yuque-client.js';
-import type { YuqueDoc, YuqueYmdDoc } from '../services/types.js';
-import { formatDocSummary, formatDoc } from '../utils/format.js';
+import {
+  formatDocSummary,
+  formatDoc,
+  formatYmdDoc,
+  formatYmdDocWriteResult,
+} from '../utils/format.js';
 
 async function appendDocToToc(
   client: YuqueClient,
@@ -27,26 +31,46 @@ function shouldUseYmd(format?: string): boolean {
   return !format || format === 'markdown';
 }
 
-function withYmdBody(doc: YuqueDoc, ymdDoc: YuqueYmdDoc): YuqueDoc {
-  return {
-    ...doc,
-    title: ymdDoc.title || doc.title,
-    body: ymdDoc.yfm,
-    format: 'markdown',
-    updated_at: ymdDoc.updated_at || doc.updated_at,
-  };
+/** The YMD API only accepts numeric doc IDs, so slugs need one extra lookup. */
+async function resolveDocId(
+  client: YuqueClient,
+  repoId: string | number,
+  docId: string | number
+): Promise<number> {
+  if (typeof docId === 'number') return docId;
+  const doc = await client.getDoc(repoId, docId);
+  return doc.id;
 }
 
 export const docTools = {
   yuque_list_docs: {
-    description: 'List all documents in a repo/book',
+    description: 'List documents in a repo/book with optional pagination',
     inputSchema: z.object({
       repo_id: z
         .union([z.string(), z.number()])
         .describe('Repo ID or namespace (e.g., "mygroup/mybook")'),
+      offset: z
+        .number()
+        .int()
+        .min(0)
+        .optional()
+        .describe('Pagination offset (number of docs to skip)'),
+      limit: z
+        .number()
+        .int()
+        .min(1)
+        .max(100)
+        .optional()
+        .describe('Number of docs per page (default and max: 100)'),
     }),
-    handler: async (client: YuqueClient, args: { repo_id: string | number }) => {
-      const docs = await client.listDocs(args.repo_id);
+    handler: async (
+      client: YuqueClient,
+      args: { repo_id: string | number; offset?: number; limit?: number }
+    ) => {
+      const docs = await client.listDocs(args.repo_id, {
+        offset: args.offset,
+        limit: args.limit,
+      });
       return {
         content: [
           {
@@ -59,23 +83,28 @@ export const docTools = {
   },
 
   yuque_get_doc: {
-    description: 'Get a specific document with full content',
+    description:
+      'Get a specific document with full content. By default (format omitted or markdown) the body is read through the YMD markdown API; use format lake/html or include_lake to read through the legacy document API instead.',
     inputSchema: z.object({
       repo_id: z
         .union([z.string(), z.number()])
         .describe('Repo ID or namespace (e.g., "mygroup/mybook")'),
-      doc_id: z.union([z.string(), z.number()]).describe('Document ID or slug'),
+      doc_id: z
+        .union([z.string(), z.number()])
+        .describe('Document ID or slug. A numeric ID saves one lookup call on the markdown path.'),
       format: z
         .enum(['markdown', 'lake', 'html'])
         .optional()
         .describe(
-          'Content format to read. Omit or use markdown to read through the YMD-compatible flow; use lake/html for the legacy document API.'
+          'Content format to read. Omit or use markdown for the YMD markdown API; use lake/html for the legacy document API.'
         ),
       include_lake: z
         .boolean()
         .optional()
         .default(false)
-        .describe('Include raw Lake format body (preserves Mermaid source code, diagrams, etc.)'),
+        .describe(
+          'Include raw Lake format body (preserves Mermaid source code, diagrams, etc.). Forces the legacy document API path.'
+        ),
     }),
     handler: async (
       client: YuqueClient,
@@ -86,19 +115,25 @@ export const docTools = {
         include_lake: boolean;
       }
     ) => {
+      if (shouldUseYmd(args.format) && !args.include_lake) {
+        const docId = await resolveDocId(client, args.repo_id, args.doc_id);
+        const ymdDoc = await client.getYmdDoc(docId);
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify(formatYmdDoc(ymdDoc), null, 2),
+            },
+          ],
+        };
+      }
+
       const doc = await client.getDoc(args.repo_id, args.doc_id);
-      const formattedDoc = shouldUseYmd(args.format)
-        ? withYmdBody(doc, await client.getYmdDoc(doc.id))
-        : doc;
       return {
         content: [
           {
             type: 'text' as const,
-            text: JSON.stringify(
-              formatDoc(formattedDoc, { includeLake: args.include_lake }),
-              null,
-              2
-            ),
+            text: JSON.stringify(formatDoc(doc, { includeLake: args.include_lake }), null, 2),
           },
         ],
       };
@@ -151,12 +186,15 @@ export const docTools = {
   },
 
   yuque_update_doc: {
-    description: 'Update an existing document',
+    description:
+      'Update an existing document. Exactly one Yuque write API is used per call: a markdown body (format omitted or markdown) goes through the YMD markdown API and cannot be combined with title/slug/public changes — update metadata in a separate call. Metadata-only updates and lake/html bodies go through the legacy document API.',
     inputSchema: z.object({
       repo_id: z
         .union([z.string(), z.number()])
         .describe('Repo ID or namespace (e.g., "mygroup/mybook")'),
-      doc_id: z.union([z.string(), z.number()]).describe('Document ID or slug'),
+      doc_id: z
+        .union([z.string(), z.number()])
+        .describe('Document ID or slug. A numeric ID saves one lookup call on the markdown path.'),
       title: z.string().optional().describe('New document title'),
       slug: z.string().optional().describe('New document slug'),
       body: z.string().optional().describe('New document content'),
@@ -164,7 +202,7 @@ export const docTools = {
         .enum(['markdown', 'lake', 'html'])
         .optional()
         .describe(
-          'Content format for body. Omit or use markdown to write through the YMD-compatible flow; use lake/html for the legacy document API.'
+          'Content format for body. Omit or use markdown for the YMD markdown API; use lake/html for the legacy document API.'
         ),
       public: z.number().optional().describe('Public visibility: 0 (private) or 1 (public)'),
     }),
@@ -188,17 +226,19 @@ export const docTools = {
       const hasMetadataUpdate = Object.values(metadata).some((value) => value !== undefined);
 
       if (args.body !== undefined && shouldUseYmd(args.format)) {
-        const currentDoc = await client.getDoc(args.repo_id, args.doc_id);
-        const doc = hasMetadataUpdate
-          ? await client.updateDoc(args.repo_id, args.doc_id, metadata)
-          : currentDoc;
-        await client.updateYmdDoc(currentDoc.id, args.body);
-        const ymdDoc = await client.getYmdDoc(currentDoc.id);
+        if (hasMetadataUpdate) {
+          throw new Error(
+            'A markdown body update goes through the YMD API and cannot change title/slug/public in the same call. ' +
+              'Call yuque_update_doc twice: once with only metadata fields, once with only body.'
+          );
+        }
+        const docId = await resolveDocId(client, args.repo_id, args.doc_id);
+        const writeResult = await client.updateYmdDoc(docId, args.body);
         return {
           content: [
             {
               type: 'text' as const,
-              text: JSON.stringify(formatDoc(withYmdBody(doc, ymdDoc)), null, 2),
+              text: JSON.stringify(formatYmdDocWriteResult(writeResult), null, 2),
             },
           ],
         };

--- a/src/tools/note.ts
+++ b/src/tools/note.ts
@@ -2,6 +2,15 @@ import { z } from 'zod';
 import type { YuqueClient } from '../services/yuque-client.js';
 import type { YuqueNote } from '../services/types.js';
 
+/** Escape HTML special characters so note content cannot break the HTML wrapper. */
+function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
 /** Format note summary — excludes full content to reduce token usage. */
 function formatNoteSummary(note: YuqueNote) {
   return {
@@ -127,7 +136,7 @@ export const noteTools = {
     handler: async (client: YuqueClient, args: { note_id: number; body: string }) => {
       const note = await client.updateNote(args.note_id, {
         source: args.body,
-        html: `<p>${args.body}</p>`,
+        html: `<p>${escapeHtml(args.body)}</p>`,
         abstract: args.body.substring(0, 200),
       });
       return {

--- a/src/tools/search.ts
+++ b/src/tools/search.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import type { YuqueClient } from '../services/yuque-client.js';
+import { formatSearchResult } from '../utils/format.js';
 
 export const searchTools = {
   yuque_search: {
@@ -9,14 +10,18 @@ export const searchTools = {
       type: z
         .enum(['doc', 'repo'])
         .describe('Search type: doc (documents), repo (knowledge bases)'),
+      page: z.number().int().min(1).optional().describe('Page number (default: 1)'),
     }),
-    handler: async (client: YuqueClient, args: { query: string; type: 'doc' | 'repo' }) => {
-      const result = await client.search(args.query, args.type);
+    handler: async (
+      client: YuqueClient,
+      args: { query: string; type: 'doc' | 'repo'; page?: number }
+    ) => {
+      const result = await client.search(args.query, args.type, args.page);
       return {
         content: [
           {
             type: 'text' as const,
-            text: JSON.stringify(result ?? [], null, 2),
+            text: JSON.stringify(formatSearchResult(result), null, 2),
           },
         ],
       };

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -15,7 +15,7 @@ function statusHint(status: number): string {
     case 400:
       return 'Bad request — check the parameters';
     case 401:
-      return 'Unauthorized — the API token (YUQUE_PERSONAL_TOKEN) may be invalid or expired';
+      return 'Unauthorized — the API token (YUQUE_TOKEN) may be invalid or expired';
     case 403:
       return 'Forbidden — insufficient permissions for this resource';
     case 404:

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -1,4 +1,12 @@
-import type { YuqueUser, YuqueRepo, YuqueDoc, YuqueTocItem } from '../services/types.js';
+import type {
+  YuqueUser,
+  YuqueRepo,
+  YuqueDoc,
+  YuqueYmdDoc,
+  YuqueYmdDocWriteResult,
+  YuqueTocItem,
+  YuqueSearchResult,
+} from '../services/types.js';
 
 /** Format user data — strips fields that are noisy for AI consumption. */
 export function formatUser(user: YuqueUser) {
@@ -48,6 +56,52 @@ export function formatDoc(doc: YuqueDoc, options?: { includeLake?: boolean }) {
     body_html: doc.body_html,
     description: doc.description,
     ...(options?.includeLake && { body_lake: doc.body_lake }),
+  };
+}
+
+/** Format a YMD markdown doc view. */
+export function formatYmdDoc(doc: YuqueYmdDoc) {
+  return {
+    id: doc.doc_id,
+    title: doc.title,
+    url: doc.url,
+    format: 'markdown',
+    body: doc.yfm,
+    updated_at: doc.updated_at,
+  };
+}
+
+/** Format the result of a YMD markdown doc write. */
+export function formatYmdDocWriteResult(result: YuqueYmdDocWriteResult) {
+  return {
+    id: result.doc_id,
+    title: result.title,
+    url: result.url,
+    updated_at: result.updated_at,
+  };
+}
+
+/** Strip Yuque search highlight tags (<em>) and other HTML from a snippet. */
+function stripHtml(text: string): string {
+  return text.replace(/<[^>]*>/g, '');
+}
+
+/** Format search results — strips highlight markup and trims to essential fields. */
+export function formatSearchResult(result: YuqueSearchResult | null | undefined) {
+  if (!result || !Array.isArray(result.items)) {
+    return { total: 0, items: [] };
+  }
+  return {
+    total: result.total,
+    items: result.items.map((item) => ({
+      id: item.id,
+      type: item.type,
+      title: stripHtml(item.title ?? ''),
+      summary: stripHtml(item.body ?? ''),
+      url: item.url,
+      ...(item.book && { book: item.book }),
+      updated_at: item.updated_at,
+    })),
   };
 }
 

--- a/tests/cli-install-setup.test.ts
+++ b/tests/cli-install-setup.test.ts
@@ -62,14 +62,14 @@ describe('runSetup', () => {
     const clientConfig = module.getClientConfig('claude-desktop');
     if (!clientConfig) throw new Error('claude-desktop config missing');
     clientConfig.getConfigPath = () => configPath;
-    readlineMock.answers = ['setup-token', '1', 'https://yuque.internal/api/v2'];
+    readlineMock.answers = ['setup-token', '1', 'https://yuque.internal'];
 
     await module.runSetup();
 
     const content = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
     expect(content.mcpServers.yuque.env).toEqual({
-      YUQUE_PERSONAL_TOKEN: 'setup-token',
-      YUQUE_BASE_URL: 'https://yuque.internal/api/v2',
+      YUQUE_TOKEN: 'setup-token',
+      YUQUE_HOST: 'https://yuque.internal',
     });
     expect(readlineMock.close).toHaveBeenCalledTimes(1);
     expect(log).toHaveBeenCalledWith(expect.stringContaining('Successfully configured'));

--- a/tests/cli-install.test.ts
+++ b/tests/cli-install.test.ts
@@ -185,7 +185,7 @@ describe('installToClient', () => {
           command: 'npx',
           args: ['-y', 'yuque-mcp'],
           env: {
-            YUQUE_PERSONAL_TOKEN: 'test-token-123',
+            YUQUE_TOKEN: 'test-token-123',
           },
         },
       },
@@ -206,7 +206,7 @@ describe('installToClient', () => {
           command: 'npx',
           args: ['-y', 'yuque-mcp'],
           env: {
-            YUQUE_PERSONAL_TOKEN: 'vsc-token',
+            YUQUE_TOKEN: 'vsc-token',
           },
         },
       },
@@ -247,7 +247,7 @@ describe('installToClient', () => {
       command: 'npx',
       args: ['-y', 'yuque-mcp'],
       env: {
-        YUQUE_PERSONAL_TOKEN: 'merge-token',
+        YUQUE_TOKEN: 'merge-token',
       },
     });
   });
@@ -264,7 +264,7 @@ describe('installToClient', () => {
               command: 'npx',
               args: ['-y', 'yuque-mcp'],
               env: {
-                YUQUE_PERSONAL_TOKEN: 'old-token',
+                YUQUE_TOKEN: 'old-token',
               },
             },
           },
@@ -279,7 +279,7 @@ describe('installToClient', () => {
     installToClient({ token: 'new-token', client: 'cursor' });
 
     const content = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
-    expect(content.mcpServers['yuque'].env.YUQUE_PERSONAL_TOKEN).toBe('new-token');
+    expect(content.mcpServers['yuque'].env.YUQUE_TOKEN).toBe('new-token');
     // Should only have one entry
     expect(Object.keys(content.mcpServers)).toEqual(['yuque']);
   });
@@ -308,7 +308,24 @@ describe('installToClient', () => {
     expect(content.mcpServers.yuque).toBeDefined();
   });
 
-  it('should include custom base URL in standard client env', () => {
+  it('should include custom host in standard client env', () => {
+    const configPath = path.join(tmpDir, 'host', 'mcp.json');
+    mockConfigPath('cursor', configPath);
+
+    installToClient({
+      token: 'host-token',
+      client: 'cursor',
+      host: 'https://yuque.internal',
+    });
+
+    const content = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+    expect(content.mcpServers.yuque.env).toEqual({
+      YUQUE_TOKEN: 'host-token',
+      YUQUE_HOST: 'https://yuque.internal',
+    });
+  });
+
+  it('should keep legacy baseURL callers working', () => {
     const configPath = path.join(tmpDir, 'base-url', 'mcp.json');
     mockConfigPath('cursor', configPath);
 
@@ -320,8 +337,8 @@ describe('installToClient', () => {
 
     const content = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
     expect(content.mcpServers.yuque.env).toEqual({
-      YUQUE_PERSONAL_TOKEN: 'base-token',
-      YUQUE_BASE_URL: 'https://yuque.internal/api/v2',
+      YUQUE_TOKEN: 'base-token',
+      YUQUE_HOST: 'https://yuque.internal/api/v2',
     });
   });
 
@@ -333,7 +350,7 @@ describe('installToClient', () => {
 
     expect(fs.existsSync(configPath)).toBe(true);
     const content = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
-    expect(content.mcpServers.yuque.env.YUQUE_PERSONAL_TOKEN).toBe('deep-token');
+    expect(content.mcpServers.yuque.env.YUQUE_TOKEN).toBe('deep-token');
   });
 
   it('should throw for unknown client', () => {
@@ -354,7 +371,7 @@ describe('installToClient', () => {
     expect(fs.existsSync(configPath + '.backup')).toBe(true);
     // New valid config should exist
     const content = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
-    expect(content.mcpServers.yuque.env.YUQUE_PERSONAL_TOKEN).toBe('fix-token');
+    expect(content.mcpServers.yuque.env.YUQUE_TOKEN).toBe('fix-token');
   });
 
   it('should work for claude-desktop client', () => {
@@ -407,7 +424,7 @@ describe('installToClient', () => {
     const content = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
     expect(content.mcpServers.yuque).toBeDefined();
     expect(content.mcpServers.yuque.command).toBe('npx');
-    expect(content.mcpServers.yuque.env.YUQUE_PERSONAL_TOKEN).toBe('qoder-tok');
+    expect(content.mcpServers.yuque.env.YUQUE_TOKEN).toBe('qoder-tok');
   });
 
   it('should work for opencode client with custom format', () => {
@@ -422,7 +439,7 @@ describe('installToClient', () => {
       type: 'local',
       command: ['npx', '-y', 'yuque-mcp'],
       environment: {
-        YUQUE_PERSONAL_TOKEN: 'opencode-tok',
+        YUQUE_TOKEN: 'opencode-tok',
       },
       enabled: true,
     });
@@ -430,20 +447,20 @@ describe('installToClient', () => {
     expect(content.mcpServers).toBeUndefined();
   });
 
-  it('should include custom base URL in opencode environment', () => {
-    const configPath = path.join(tmpDir, 'opencode-base-url', 'opencode.json');
+  it('should include custom host in opencode environment', () => {
+    const configPath = path.join(tmpDir, 'opencode-host', 'opencode.json');
     mockConfigPath('opencode', configPath);
 
     installToClient({
-      token: 'opencode-base-token',
+      token: 'opencode-host-token',
       client: 'opencode',
-      baseURL: 'https://yuque.internal/api/v2',
+      host: 'https://yuque.internal',
     });
 
     const content = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
     expect(content.mcp.yuque.environment).toEqual({
-      YUQUE_PERSONAL_TOKEN: 'opencode-base-token',
-      YUQUE_BASE_URL: 'https://yuque.internal/api/v2',
+      YUQUE_TOKEN: 'opencode-host-token',
+      YUQUE_HOST: 'https://yuque.internal',
     });
   });
 
@@ -484,7 +501,7 @@ describe('installToClient', () => {
       type: 'local',
       command: ['npx', '-y', 'yuque-mcp'],
       environment: {
-        YUQUE_PERSONAL_TOKEN: 'oc-merge-tok',
+        YUQUE_TOKEN: 'oc-merge-tok',
       },
       enabled: true,
     });
@@ -518,7 +535,7 @@ describe('installToClient', () => {
     expect(content.servers['github-copilot']).toBeDefined();
     // Yuque added under 'servers' (not 'mcpServers')
     expect(content.servers['yuque']).toBeDefined();
-    expect(content.servers['yuque'].env.YUQUE_PERSONAL_TOKEN).toBe('vsc-merge-tok');
+    expect(content.servers['yuque'].env.YUQUE_TOKEN).toBe('vsc-merge-tok');
     // No mcpServers key should exist
     expect(content.mcpServers).toBeUndefined();
   });
@@ -530,6 +547,21 @@ describe('runInstall', () => {
     const log = vi.spyOn(console, 'log').mockImplementation(() => {});
     mockConfigPath('cursor', configPath);
 
+    runInstall(['--token=token=with=equals', '--client=cursor', '--host=https://yuque.internal']);
+
+    const content = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+    expect(content.mcpServers.yuque.env).toEqual({
+      YUQUE_TOKEN: 'token=with=equals',
+      YUQUE_HOST: 'https://yuque.internal',
+    });
+    expect(log).toHaveBeenCalledWith(expect.stringContaining('Successfully configured'));
+  });
+
+  it('should accept legacy --base-url in CLI arguments', () => {
+    const configPath = path.join(tmpDir, 'run-install-base-url', 'mcp.json');
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    mockConfigPath('cursor', configPath);
+
     runInstall([
       '--token=token=with=equals',
       '--client=cursor',
@@ -538,10 +570,9 @@ describe('runInstall', () => {
 
     const content = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
     expect(content.mcpServers.yuque.env).toEqual({
-      YUQUE_PERSONAL_TOKEN: 'token=with=equals',
-      YUQUE_BASE_URL: 'https://yuque.internal/api/v2',
+      YUQUE_TOKEN: 'token=with=equals',
+      YUQUE_HOST: 'https://yuque.internal/api/v2',
     });
-    expect(log).toHaveBeenCalledWith(expect.stringContaining('Successfully configured'));
   });
 
   it('should exit when token argument is missing', () => {

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -14,8 +14,10 @@ vi.mock('../src/server.js', () => ({
 }));
 
 const originalArgv = process.argv;
-const originalToken = process.env.YUQUE_PERSONAL_TOKEN;
-const originalBaseURL = process.env.YUQUE_BASE_URL;
+const originalToken = process.env.YUQUE_TOKEN;
+const originalLegacyToken = process.env.YUQUE_PERSONAL_TOKEN;
+const originalHost = process.env.YUQUE_HOST;
+const originalLegacyBaseURL = process.env.YUQUE_BASE_URL;
 const originalIsTTY = Object.getOwnPropertyDescriptor(process.stdin, 'isTTY');
 let cliImportRun = 0;
 
@@ -63,7 +65,9 @@ describe('CLI entry', () => {
     cliMocks.handleCliSubcommands.mockReturnValue(false);
     cliMocks.runStdioServer.mockResolvedValue(undefined);
     process.argv = ['node', 'cli.js'];
+    delete process.env.YUQUE_TOKEN;
     delete process.env.YUQUE_PERSONAL_TOKEN;
+    delete process.env.YUQUE_HOST;
     delete process.env.YUQUE_BASE_URL;
     setIsTTY(false);
   });
@@ -71,8 +75,10 @@ describe('CLI entry', () => {
   afterEach(() => {
     vi.restoreAllMocks();
     process.argv = originalArgv;
-    restoreEnv('YUQUE_PERSONAL_TOKEN', originalToken);
-    restoreEnv('YUQUE_BASE_URL', originalBaseURL);
+    restoreEnv('YUQUE_TOKEN', originalToken);
+    restoreEnv('YUQUE_PERSONAL_TOKEN', originalLegacyToken);
+    restoreEnv('YUQUE_HOST', originalHost);
+    restoreEnv('YUQUE_BASE_URL', originalLegacyBaseURL);
     if (originalIsTTY) {
       Object.defineProperty(process.stdin, 'isTTY', originalIsTTY);
     }
@@ -95,13 +101,13 @@ describe('CLI entry', () => {
     await expect(importCli()).rejects.toThrow('exit:1');
 
     expect(error).toHaveBeenCalledWith(
-      'Error: YUQUE_PERSONAL_TOKEN environment variable or --token argument is required'
+      'Error: YUQUE_TOKEN environment variable, YUQUE_PERSONAL_TOKEN environment variable, or --token argument is required'
     );
   });
 
   it('should print terminal guidance when run directly in a TTY', async () => {
     const log = vi.spyOn(console, 'log').mockImplementation(() => {});
-    process.env.YUQUE_PERSONAL_TOKEN = 'env-token';
+    process.env.YUQUE_TOKEN = 'env-token';
     setIsTTY(true);
     mockExit();
 
@@ -112,12 +118,7 @@ describe('CLI entry', () => {
   });
 
   it('should start stdio server with token and base URL arguments', async () => {
-    process.argv = [
-      'node',
-      'cli.js',
-      '--token=arg-token',
-      '--base-url=https://yuque.internal/api/v2',
-    ];
+    process.argv = ['node', 'cli.js', '--token=arg-token', '--host=https://yuque.internal'];
 
     await importCli();
 
@@ -129,7 +130,7 @@ describe('CLI entry', () => {
 
   it('should exit when stdio startup fails', async () => {
     const error = vi.spyOn(console, 'error').mockImplementation(() => {});
-    process.env.YUQUE_PERSONAL_TOKEN = 'env-token';
+    process.env.YUQUE_TOKEN = 'env-token';
     cliMocks.runStdioServer.mockRejectedValue(new Error('stdio failed'));
     mockExit(false);
 

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,9 +1,25 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 
-type HttpHandler = (
-  req: unknown,
-  res: { statusCode?: number; end: (body: string) => void }
-) => void;
+type HttpHandler = (req: unknown, res: MockRes) => void;
+
+interface MockRes {
+  statusCode: number;
+  headersSent: boolean;
+  writeHead: ReturnType<typeof vi.fn>;
+  end: ReturnType<typeof vi.fn>;
+}
+
+interface MockTransport {
+  handleRequest: ReturnType<typeof vi.fn>;
+  sessionId?: string;
+  onclose?: () => void;
+  options: {
+    sessionIdGenerator: () => string;
+    enableDnsRebindingProtection?: boolean;
+    allowedHosts?: string[];
+    onsessioninitialized?: (sid: string) => void;
+  };
+}
 
 const indexMocks = vi.hoisted(() => ({
   createMCPServer: vi.fn(),
@@ -11,7 +27,7 @@ const indexMocks = vi.hoisted(() => ({
   handleRequest: vi.fn(),
   listen: vi.fn(),
   httpHandler: undefined as HttpHandler | undefined,
-  sessionId: undefined as string | undefined,
+  transports: [] as MockTransport[],
 }));
 
 vi.mock('../src/server.js', () => ({
@@ -20,11 +36,12 @@ vi.mock('../src/server.js', () => ({
 
 vi.mock('@modelcontextprotocol/sdk/server/streamableHttp.js', () => ({
   StreamableHTTPServerTransport: vi.fn(function (
-    this: { handleRequest: typeof indexMocks.handleRequest },
-    options: { sessionIdGenerator: () => string }
+    this: MockTransport,
+    options: MockTransport['options']
   ) {
-    indexMocks.sessionId = options.sessionIdGenerator();
+    this.options = options;
     this.handleRequest = indexMocks.handleRequest;
+    indexMocks.transports.push(this);
   }),
 }));
 
@@ -42,9 +59,12 @@ vi.mock('node:crypto', () => ({
 }));
 
 const originalArgv = process.argv;
-const originalToken = process.env.YUQUE_PERSONAL_TOKEN;
-const originalBaseURL = process.env.YUQUE_BASE_URL;
+const originalToken = process.env.YUQUE_TOKEN;
+const originalLegacyToken = process.env.YUQUE_PERSONAL_TOKEN;
+const originalHost = process.env.YUQUE_HOST;
+const originalLegacyBaseURL = process.env.YUQUE_BASE_URL;
 const originalPort = process.env.PORT;
+const originalBindHost = process.env.HOST;
 let indexImportRun = 0;
 
 function restoreEnv(name: string, value: string | undefined) {
@@ -56,11 +76,15 @@ function restoreEnv(name: string, value: string | undefined) {
 }
 
 async function importHttpEntry() {
+  // Each test needs a fresh module instance; static query strings defeat the ESM cache.
   const importers = [
     () => import('../src/index.js?case=0'),
     () => import('../src/index.js?case=1'),
     () => import('../src/index.js?case=2'),
     () => import('../src/index.js?case=3'),
+    () => import('../src/index.js?case=4'),
+    () => import('../src/index.js?case=5'),
+    () => import('../src/index.js?case=6'),
   ];
   const importer = importers[indexImportRun++];
   if (!importer) throw new Error('No HTTP entry import slot left');
@@ -76,30 +100,85 @@ function mockExit(throws = true) {
   });
 }
 
+function makeReq(
+  method: string,
+  headers: Record<string, string> = {},
+  body?: unknown
+): AsyncIterable<Buffer> & { method: string; headers: Record<string, string> } {
+  return {
+    method,
+    headers,
+    async *[Symbol.asyncIterator]() {
+      if (body !== undefined) {
+        yield Buffer.from(JSON.stringify(body));
+      }
+    },
+  };
+}
+
+function makeRes(): MockRes {
+  const res: MockRes = {
+    statusCode: 200,
+    headersSent: false,
+    writeHead: vi.fn((status: number) => {
+      res.statusCode = status;
+      res.headersSent = true;
+      return res;
+    }),
+    end: vi.fn(),
+  };
+  return res;
+}
+
+const initializeBody = {
+  jsonrpc: '2.0',
+  id: 1,
+  method: 'initialize',
+  params: {
+    protocolVersion: '2025-03-26',
+    capabilities: {},
+    clientInfo: { name: 'test-client', version: '1.0.0' },
+  },
+};
+
+async function dispatch(req: unknown, res: MockRes) {
+  indexMocks.httpHandler?.(req, res);
+  // Drain the async handler chain.
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
 describe('HTTP entry', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.resetModules();
     indexMocks.connect.mockResolvedValue(undefined);
     indexMocks.handleRequest.mockResolvedValue(undefined);
-    indexMocks.listen.mockImplementation((_port: number, callback: () => void) => callback());
+    indexMocks.listen.mockImplementation((_port: number, _host: string, callback: () => void) =>
+      callback()
+    );
     indexMocks.createMCPServer.mockReturnValue({
       connect: indexMocks.connect,
     });
     indexMocks.httpHandler = undefined;
-    indexMocks.sessionId = undefined;
+    indexMocks.transports = [];
     process.argv = ['node', 'index.js'];
+    delete process.env.YUQUE_TOKEN;
     delete process.env.YUQUE_PERSONAL_TOKEN;
+    delete process.env.YUQUE_HOST;
     delete process.env.YUQUE_BASE_URL;
     delete process.env.PORT;
+    delete process.env.HOST;
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
     process.argv = originalArgv;
-    restoreEnv('YUQUE_PERSONAL_TOKEN', originalToken);
-    restoreEnv('YUQUE_BASE_URL', originalBaseURL);
+    restoreEnv('YUQUE_TOKEN', originalToken);
+    restoreEnv('YUQUE_PERSONAL_TOKEN', originalLegacyToken);
+    restoreEnv('YUQUE_HOST', originalHost);
+    restoreEnv('YUQUE_BASE_URL', originalLegacyBaseURL);
     restoreEnv('PORT', originalPort);
+    restoreEnv('HOST', originalBindHost);
   });
 
   it('should exit when token is missing', async () => {
@@ -109,71 +188,131 @@ describe('HTTP entry', () => {
     await expect(importHttpEntry()).rejects.toThrow('exit:1');
 
     expect(error).toHaveBeenCalledWith(
-      'Error: YUQUE_PERSONAL_TOKEN environment variable or --token argument is required'
+      'Error: YUQUE_TOKEN environment variable, YUQUE_PERSONAL_TOKEN environment variable, or --token argument is required'
     );
   });
 
-  it('should start HTTP server and handle request failures', async () => {
+  it('should bind to loopback with the default port', async () => {
     const log = vi.spyOn(console, 'log').mockImplementation(() => {});
-    const error = vi.spyOn(console, 'error').mockImplementation(() => {});
-    process.argv = [
-      'node',
-      'index.js',
-      '--token=arg-token',
-      '--base-url=https://yuque.internal/api/v2',
-    ];
+    process.env.YUQUE_TOKEN = 'env-token';
+
+    await importHttpEntry();
+
+    expect(indexMocks.listen).toHaveBeenCalledWith(3000, '127.0.0.1', expect.any(Function));
+    expect(log).toHaveBeenCalledWith('Yuque MCP Server running on http://127.0.0.1:3000');
+  });
+
+  it('should create one session per initialize request and route follow-ups by session id', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    process.argv = ['node', 'index.js', '--token=arg-token', '--host=https://yuque.internal'];
     process.env.PORT = '4242';
 
     await importHttpEntry();
-    await Promise.resolve();
 
+    expect(indexMocks.listen).toHaveBeenCalledWith(4242, '127.0.0.1', expect.any(Function));
+
+    // Initialize request without a session id creates a fresh transport + MCP server.
+    const initReq = makeReq('POST', {}, initializeBody);
+    const initRes = makeRes();
+    await dispatch(initReq, initRes);
+
+    expect(indexMocks.transports).toHaveLength(1);
     expect(indexMocks.createMCPServer).toHaveBeenCalledWith(
       'arg-token',
       'https://yuque.internal/api/v2'
     );
-    expect(indexMocks.sessionId).toBe('uuid-1');
-    expect(indexMocks.listen).toHaveBeenCalledWith(4242, expect.any(Function));
-    expect(log).toHaveBeenCalledWith('Yuque MCP Server running on http://localhost:4242');
+    expect(indexMocks.connect).toHaveBeenCalledTimes(1);
+    expect(indexMocks.handleRequest).toHaveBeenCalledWith(initReq, initRes, initializeBody);
 
-    indexMocks.handleRequest.mockRejectedValue(new Error('request failed'));
-    const res = {
-      statusCode: 200,
-      end: vi.fn(),
-    };
-    indexMocks.httpHandler?.({}, res);
-    await Promise.resolve();
+    const transport = indexMocks.transports[0];
+    expect(transport.options.enableDnsRebindingProtection).toBe(true);
+    expect(transport.options.allowedHosts).toContain('127.0.0.1:4242');
+    expect(transport.options.sessionIdGenerator()).toBe('uuid-1');
+
+    // Session registration happens through the SDK callback.
+    transport.sessionId = 'uuid-1';
+    transport.options.onsessioninitialized?.('uuid-1');
+
+    // A follow-up request with the session id reuses the same transport.
+    const followUpReq = makeReq('POST', { 'mcp-session-id': 'uuid-1' });
+    const followUpRes = makeRes();
+    await dispatch(followUpReq, followUpRes);
+
+    expect(indexMocks.transports).toHaveLength(1);
+    expect(indexMocks.handleRequest).toHaveBeenCalledWith(followUpReq, followUpRes);
+
+    // Closing the transport unregisters the session.
+    transport.onclose?.();
+    const staleReq = makeReq('POST', { 'mcp-session-id': 'uuid-1' });
+    const staleRes = makeRes();
+    await dispatch(staleReq, staleRes);
+    expect(staleRes.statusCode).toBe(404);
+  });
+
+  it('should reject requests without a session that are not initialize', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    process.env.YUQUE_TOKEN = 'env-token';
+
+    await importHttpEntry();
+
+    const getReq = makeReq('GET');
+    const getRes = makeRes();
+    await dispatch(getReq, getRes);
+    expect(getRes.statusCode).toBe(400);
+
+    const postReq = makeReq('POST', {}, { jsonrpc: '2.0', id: 2, method: 'tools/list' });
+    const postRes = makeRes();
+    await dispatch(postReq, postRes);
+    expect(postRes.statusCode).toBe(400);
+
+    expect(indexMocks.transports).toHaveLength(0);
+  });
+
+  it('should return 404 for unknown session ids', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    process.env.YUQUE_TOKEN = 'env-token';
+
+    await importHttpEntry();
+
+    const req = makeReq('POST', { 'mcp-session-id': 'missing' });
+    const res = makeRes();
+    await dispatch(req, res);
+
+    expect(res.statusCode).toBe(404);
+    expect(indexMocks.transports).toHaveLength(0);
+  });
+
+  it('should respond with 500 when request handling fails', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+    process.env.YUQUE_TOKEN = 'env-token';
+
+    await importHttpEntry();
+
+    indexMocks.connect.mockRejectedValue(new Error('connect failed'));
+    const req = makeReq('POST', {}, initializeBody);
+    const res = makeRes();
+    await dispatch(req, res);
 
     expect(error).toHaveBeenCalledWith('Request handling error:', expect.any(Error));
     expect(res.statusCode).toBe(500);
     expect(res.end).toHaveBeenCalledWith('Internal Server Error');
   });
 
-  it('should use environment token and default port', async () => {
-    const log = vi.spyOn(console, 'log').mockImplementation(() => {});
-    process.env.YUQUE_PERSONAL_TOKEN = 'env-token';
-    process.env.YUQUE_BASE_URL = 'https://env.example/api/v2';
+  it('should disable DNS rebinding protection when HOST exposes other interfaces', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    process.env.YUQUE_TOKEN = 'env-token';
+    process.env.HOST = '0.0.0.0';
 
     await importHttpEntry();
-    await Promise.resolve();
 
-    expect(indexMocks.createMCPServer).toHaveBeenCalledWith(
-      'env-token',
-      'https://env.example/api/v2'
-    );
-    expect(indexMocks.listen).toHaveBeenCalledWith(3000, expect.any(Function));
-    expect(log).toHaveBeenCalledWith('Yuque MCP Server running on http://localhost:3000');
-  });
+    expect(indexMocks.listen).toHaveBeenCalledWith(3000, '0.0.0.0', expect.any(Function));
 
-  it('should exit when MCP server connection fails', async () => {
-    const error = vi.spyOn(console, 'error').mockImplementation(() => {});
-    process.env.YUQUE_PERSONAL_TOKEN = 'env-token';
-    indexMocks.connect.mockRejectedValue(new Error('connect failed'));
-    mockExit(false);
+    const req = makeReq('POST', {}, initializeBody);
+    const res = makeRes();
+    await dispatch(req, res);
 
-    await importHttpEntry();
-    await Promise.resolve();
-
-    expect(error).toHaveBeenCalledWith('Failed to start server:', expect.any(Error));
-    expect(process.exit).toHaveBeenCalledWith(1);
+    expect(indexMocks.transports).toHaveLength(1);
+    expect(indexMocks.transports[0].options.enableDnsRebindingProtection).toBe(false);
   });
 });

--- a/tests/mcp/server-manifest-contract.test.ts
+++ b/tests/mcp/server-manifest-contract.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import serverManifest from '../../server.json';
+
+type ServerManifest = {
+  packages: Array<{
+    environmentVariables?: Array<{
+      name: string;
+      isRequired: boolean;
+      isSecret: boolean;
+    }>;
+  }>;
+};
+
+describe('MCP server manifest contract', () => {
+  it('should expose only the supported Yuque token and host variables', () => {
+    const manifest = serverManifest as ServerManifest;
+    const envVars = manifest.packages[0]?.environmentVariables ?? [];
+
+    expect(envVars.map((envVar) => envVar.name)).toEqual(['YUQUE_TOKEN', 'YUQUE_HOST']);
+    expect(envVars).toEqual([
+      expect.objectContaining({
+        name: 'YUQUE_TOKEN',
+        isRequired: true,
+        isSecret: true,
+      }),
+      expect.objectContaining({
+        name: 'YUQUE_HOST',
+        isRequired: false,
+        isSecret: false,
+      }),
+    ]);
+  });
+});

--- a/tests/mcp/tool-call-contract.test.ts
+++ b/tests/mcp/tool-call-contract.test.ts
@@ -166,7 +166,7 @@ const toolCases: ToolCase[] = [
     },
     assert: (http, result) => {
       expect(parseJson(result)[0]).toMatchObject({ namespace: 'user/book', public: true });
-      expect(http.get).toHaveBeenCalledWith('/users/tester/repos');
+      expect(http.get).toHaveBeenCalledWith('/users/tester/repos', { params: {} });
     },
   },
   {
@@ -216,7 +216,7 @@ const toolCases: ToolCase[] = [
     },
     assert: (http, result) => {
       expect(parseJson(result)[0]).toMatchObject({ title: 'Doc' });
-      expect(http.get).toHaveBeenCalledWith('/repos/1/docs');
+      expect(http.get).toHaveBeenCalledWith('/repos/1/docs', { params: {} });
     },
   },
   {

--- a/tests/mcp/tool-registry-contract.test.ts
+++ b/tests/mcp/tool-registry-contract.test.ts
@@ -38,7 +38,7 @@ const expectedToolNames = [
 
 const requiredFieldsByTool: Record<string, string[]> = {
   yuque_get_user: [],
-  yuque_list_books: ['login'],
+  yuque_list_books: [],
   yuque_get_book: ['repo_id'],
   yuque_create_book: ['login', 'name', 'slug'],
   yuque_update_book: ['repo_id'],

--- a/tests/real-api/smoke.test.ts
+++ b/tests/real-api/smoke.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest';
+import { resolveYuqueBaseURL } from '../../src/config.js';
 import { createServer } from '../../src/server.js';
 
 type ToolResult = {
@@ -20,7 +21,9 @@ const realApiEnabled = process.env.YUQUE_REAL_API === '1';
 const repoId = process.env.YUQUE_REAL_REPO_ID;
 const noteId = process.env.YUQUE_REAL_WRITE_NOTE_ID;
 const writeEnabled = realApiEnabled && process.env.YUQUE_REAL_WRITE === '1' && noteId;
-const token = process.env.YUQUE_PERSONAL_TOKEN ?? process.env.YUQUE_MCP_TEST_TOKEN;
+const token =
+  process.env.YUQUE_TOKEN ?? process.env.YUQUE_PERSONAL_TOKEN ?? process.env.YUQUE_MCP_TEST_TOKEN;
+const baseURL = resolveYuqueBaseURL(['node', 'smoke.test.ts'], process.env);
 
 function getRequestHandler<T>(server: unknown, method: string) {
   return (
@@ -33,10 +36,10 @@ function getRequestHandler<T>(server: unknown, method: string) {
 async function callRealTool(name: string, args: Record<string, unknown>) {
   if (!token) {
     throw new Error(
-      'YUQUE_PERSONAL_TOKEN or YUQUE_MCP_TEST_TOKEN is required for real API smoke tests'
+      'YUQUE_TOKEN, YUQUE_PERSONAL_TOKEN, or YUQUE_MCP_TEST_TOKEN is required for real API smoke tests'
     );
   }
-  const server = createServer(token, process.env.YUQUE_BASE_URL);
+  const server = createServer(token, baseURL);
   const handler = getRequestHandler<ToolResult>(server, 'tools/call');
   if (!handler) throw new Error('tools/call handler missing');
 

--- a/tests/services/yuque-client.test.ts
+++ b/tests/services/yuque-client.test.ts
@@ -102,16 +102,6 @@ describe('YuqueClient', () => {
   });
 
   describe('repo operations', () => {
-    it('should list groups for a user', async () => {
-      const mockGroups = [{ id: 1, login: 'team', name: 'Team' }];
-      const mockClient = client['client'] as { get: ReturnType<typeof vi.fn> };
-      mockClient.get.mockResolvedValue({ data: { data: mockGroups } });
-
-      const result = await client.listGroups(123);
-      expect(result).toEqual(mockGroups);
-      expect(mockClient.get).toHaveBeenCalledWith('/users/123/groups');
-    });
-
     it('should list user repos', async () => {
       const mockRepos = [
         {
@@ -130,17 +120,17 @@ describe('YuqueClient', () => {
 
       const result = await client.listUserRepos('testuser');
       expect(result).toEqual(mockRepos);
-      expect(mockClient.get).toHaveBeenCalledWith('/users/testuser/repos');
+      expect(mockClient.get).toHaveBeenCalledWith('/users/testuser/repos', { params: {} });
     });
 
-    it('should list group repos', async () => {
-      const mockRepos = [{ id: 1, name: 'Group Repo' }];
+    it('should list user repos with pagination', async () => {
       const mockClient = client['client'] as { get: ReturnType<typeof vi.fn> };
-      mockClient.get.mockResolvedValue({ data: { data: mockRepos } });
+      mockClient.get.mockResolvedValue({ data: { data: [] } });
 
-      const result = await client.listGroupRepos('team');
-      expect(result).toEqual(mockRepos);
-      expect(mockClient.get).toHaveBeenCalledWith('/groups/team/repos');
+      await client.listUserRepos('testuser', { offset: 20, limit: 10 });
+      expect(mockClient.get).toHaveBeenCalledWith('/users/testuser/repos', {
+        params: { offset: 20, limit: 10 },
+      });
     });
 
     it('should get repo by ID', async () => {
@@ -191,22 +181,6 @@ describe('YuqueClient', () => {
       });
     });
 
-    it('should create group repo', async () => {
-      const mockRepo = { id: 2, name: 'Group Repo', slug: 'group-repo' };
-      const mockClient = client['client'] as { post: ReturnType<typeof vi.fn> };
-      mockClient.post.mockResolvedValue({ data: { data: mockRepo } });
-
-      const result = await client.createGroupRepo('team', {
-        name: 'Group Repo',
-        slug: 'group-repo',
-      });
-      expect(result).toEqual(mockRepo);
-      expect(mockClient.post).toHaveBeenCalledWith('/groups/team/repos', {
-        name: 'Group Repo',
-        slug: 'group-repo',
-      });
-    });
-
     it('should update repo', async () => {
       const mockRepo = { id: 1, name: 'Updated Repo' };
       const mockClient = client['client'] as { put: ReturnType<typeof vi.fn> };
@@ -215,14 +189,6 @@ describe('YuqueClient', () => {
       const result = await client.updateRepo('team/repo', { name: 'Updated Repo' });
       expect(result).toEqual(mockRepo);
       expect(mockClient.put).toHaveBeenCalledWith('/repos/team/repo', { name: 'Updated Repo' });
-    });
-
-    it('should delete repo', async () => {
-      const mockClient = client['client'] as { delete: ReturnType<typeof vi.fn> };
-      mockClient.delete.mockResolvedValue({});
-
-      await client.deleteRepo(1);
-      expect(mockClient.delete).toHaveBeenCalledWith('/repos/1');
     });
   });
 
@@ -243,7 +209,17 @@ describe('YuqueClient', () => {
 
       const result = await client.listDocs(1);
       expect(result).toEqual(mockDocs);
-      expect(mockClient.get).toHaveBeenCalledWith('/repos/1/docs');
+      expect(mockClient.get).toHaveBeenCalledWith('/repos/1/docs', { params: {} });
+    });
+
+    it('should list docs with pagination', async () => {
+      const mockClient = client['client'] as { get: ReturnType<typeof vi.fn> };
+      mockClient.get.mockResolvedValue({ data: { data: [] } });
+
+      await client.listDocs(1, { offset: 100, limit: 50 });
+      expect(mockClient.get).toHaveBeenCalledWith('/repos/1/docs', {
+        params: { offset: 100, limit: 50 },
+      });
     });
 
     it('should get doc', async () => {
@@ -444,14 +420,6 @@ describe('YuqueClient', () => {
         dsl: nextDsl,
       });
     });
-
-    it('should delete doc', async () => {
-      const mockClient = client['client'] as { delete: ReturnType<typeof vi.fn> };
-      mockClient.delete.mockResolvedValue({});
-
-      await client.deleteDoc(1, 1);
-      expect(mockClient.delete).toHaveBeenCalledWith('/repos/1/docs/1');
-    });
   });
 
   describe('toc operations', () => {
@@ -476,95 +444,7 @@ describe('YuqueClient', () => {
     });
   });
 
-  describe('doc version operations', () => {
-    it('should list doc versions', async () => {
-      const mockVersions = [{ id: 1, doc_id: 2, title: 'v1' }];
-      const mockClient = client['client'] as { get: ReturnType<typeof vi.fn> };
-      mockClient.get.mockResolvedValue({ data: { data: mockVersions } });
-
-      const result = await client.listDocVersions(2);
-      expect(result).toEqual(mockVersions);
-      expect(mockClient.get).toHaveBeenCalledWith('/doc_versions', {
-        params: { doc_id: 2 },
-      });
-    });
-
-    it('should get a doc version', async () => {
-      const mockVersion = { id: 9, doc_id: 2, title: 'v9' };
-      const mockClient = client['client'] as { get: ReturnType<typeof vi.fn> };
-      mockClient.get.mockResolvedValue({ data: { data: mockVersion } });
-
-      const result = await client.getDocVersion(9);
-      expect(result).toEqual(mockVersion);
-      expect(mockClient.get).toHaveBeenCalledWith('/doc_versions/9');
-    });
-  });
-
-  describe('group member and statistics operations', () => {
-    it('should list group members', async () => {
-      const mockMembers = [{ id: 1, login: 'member' }];
-      const mockClient = client['client'] as { get: ReturnType<typeof vi.fn> };
-      mockClient.get.mockResolvedValue({ data: { data: mockMembers } });
-
-      const result = await client.listGroupMembers('team');
-      expect(result).toEqual(mockMembers);
-      expect(mockClient.get).toHaveBeenCalledWith('/groups/team/users');
-    });
-
-    it('should update group member role', async () => {
-      const mockMember = { id: 1, role: 2 };
-      const mockClient = client['client'] as { put: ReturnType<typeof vi.fn> };
-      mockClient.put.mockResolvedValue({ data: { data: mockMember } });
-
-      const result = await client.updateGroupMember('team', 1, { role: 2 });
-      expect(result).toEqual(mockMember);
-      expect(mockClient.put).toHaveBeenCalledWith('/groups/team/users/1', { role: 2 });
-    });
-
-    it('should remove group member', async () => {
-      const mockClient = client['client'] as { delete: ReturnType<typeof vi.fn> };
-      mockClient.delete.mockResolvedValue({});
-
-      await client.removeGroupMember('team', 1);
-      expect(mockClient.delete).toHaveBeenCalledWith('/groups/team/users/1');
-    });
-
-    it('should get group statistics', async () => {
-      const mockStats = { books_count: 3, docs_count: 10 };
-      const mockClient = client['client'] as { get: ReturnType<typeof vi.fn> };
-      mockClient.get.mockResolvedValue({ data: { data: mockStats } });
-
-      const result = await client.getGroupStats('team');
-      expect(result).toEqual(mockStats);
-      expect(mockClient.get).toHaveBeenCalledWith('/groups/team/statistics');
-    });
-
-    it.each([
-      ['member', () => client.getGroupMemberStats('team'), '/groups/team/statistics/members'],
-      ['book', () => client.getGroupBookStats('team'), '/groups/team/statistics/books'],
-      ['doc', () => client.getGroupDocStats('team'), '/groups/team/statistics/docs'],
-    ])('should get %s statistics', async (_label, call, path) => {
-      const mockStats = { total: 1 };
-      const mockClient = client['client'] as { get: ReturnType<typeof vi.fn> };
-      mockClient.get.mockResolvedValue({ data: { data: mockStats } });
-
-      const result = await call();
-      expect(result).toEqual(mockStats);
-      expect(mockClient.get).toHaveBeenCalledWith(path);
-    });
-  });
-
-  describe('hello and note operations', () => {
-    it('should call hello', async () => {
-      const mockMessage = { message: 'ok' };
-      const mockClient = client['client'] as { get: ReturnType<typeof vi.fn> };
-      mockClient.get.mockResolvedValue({ data: { data: mockMessage } });
-
-      const result = await client.hello();
-      expect(result).toEqual(mockMessage);
-      expect(mockClient.get).toHaveBeenCalledWith('/hello');
-    });
-
+  describe('note operations', () => {
     it('should list notes with params', async () => {
       const mockNotes = { notes: [], pin_notes: [], has_more: false };
       const mockClient = client['client'] as { get: ReturnType<typeof vi.fn> };
@@ -612,58 +492,6 @@ describe('YuqueClient', () => {
         source: 'updated',
         html: '<p>updated</p>',
         abstract: 'updated',
-      });
-    });
-
-    it('should delete note by moving it to trash', async () => {
-      const mockClient = client['client'] as {
-        get: ReturnType<typeof vi.fn>;
-        put: ReturnType<typeof vi.fn>;
-      };
-      mockClient.get.mockResolvedValue({
-        data: {
-          data: {
-            id: 1,
-            content: {
-              source: 'source',
-              html: '<p>source</p>',
-              abstract: 'source',
-            },
-          },
-        },
-      });
-      mockClient.put.mockResolvedValue({ data: { data: { data: { id: 1 } } } });
-
-      await client.deleteNote(1);
-      expect(mockClient.put).toHaveBeenCalledWith('/notes/1', {
-        source: 'source',
-        html: '<p>source</p>',
-        abstract: 'source',
-        status: 9,
-      });
-    });
-
-    it('should restore note from trash', async () => {
-      const mockClient = client['client'] as {
-        get: ReturnType<typeof vi.fn>;
-        put: ReturnType<typeof vi.fn>;
-      };
-      mockClient.get.mockResolvedValue({
-        data: {
-          data: {
-            id: 1,
-            content: {},
-          },
-        },
-      });
-      mockClient.put.mockResolvedValue({ data: { data: { data: { id: 1 } } } });
-
-      await client.restoreNote(1);
-      expect(mockClient.put).toHaveBeenCalledWith('/notes/1', {
-        source: '',
-        html: '',
-        abstract: '',
-        status: 0,
       });
     });
   });

--- a/tests/tools/book.test.ts
+++ b/tests/tools/book.test.ts
@@ -3,6 +3,7 @@ import { bookTools } from '../../src/tools/book.js';
 import type { YuqueClient } from '../../src/services/yuque-client.js';
 
 const mockClient = {
+  getUser: vi.fn(),
   listUserRepos: vi.fn(),
   getRepo: vi.fn(),
   createUserRepo: vi.fn(),
@@ -30,7 +31,32 @@ describe('bookTools', () => {
       } as never);
       const parsed = JSON.parse(result.content[0].text);
       expect(parsed).toHaveLength(1);
-      expect(mockClient.listUserRepos).toHaveBeenCalledWith('user');
+      expect(mockClient.listUserRepos).toHaveBeenCalledWith('user', {
+        offset: undefined,
+        limit: undefined,
+      });
+      expect(mockClient.getUser).not.toHaveBeenCalled();
+    });
+
+    it('should default to the current user when login is omitted', async () => {
+      (mockClient.getUser as ReturnType<typeof vi.fn>).mockResolvedValue({ login: 'me' });
+      (mockClient.listUserRepos as ReturnType<typeof vi.fn>).mockResolvedValue([mockRepo]);
+      await bookTools.yuque_list_books.handler(mockClient, {} as never);
+      expect(mockClient.getUser).toHaveBeenCalled();
+      expect(mockClient.listUserRepos).toHaveBeenCalledWith('me', {
+        offset: undefined,
+        limit: undefined,
+      });
+    });
+
+    it('should pass pagination options through', async () => {
+      (mockClient.listUserRepos as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+      await bookTools.yuque_list_books.handler(mockClient, {
+        login: 'user',
+        offset: 20,
+        limit: 10,
+      } as never);
+      expect(mockClient.listUserRepos).toHaveBeenCalledWith('user', { offset: 20, limit: 10 });
     });
   });
 

--- a/tests/tools/doc.test.ts
+++ b/tests/tools/doc.test.ts
@@ -9,7 +9,6 @@ const mockClient = {
   createDoc: vi.fn(),
   updateDoc: vi.fn(),
   updateYmdDoc: vi.fn(),
-  deleteDoc: vi.fn(),
   updateToc: vi.fn(),
 } as unknown as YuqueClient;
 
@@ -33,29 +32,31 @@ describe('docTools', () => {
       const parsed = JSON.parse(result.content[0].text);
       expect(parsed).toHaveLength(1);
       expect(parsed[0]).toHaveProperty('title', 'Doc 1');
-      expect(mockClient.listDocs).toHaveBeenCalledWith(1);
+      expect(mockClient.listDocs).toHaveBeenCalledWith(1, { offset: undefined, limit: undefined });
     });
 
     it('should accept namespace string', async () => {
       (mockClient.listDocs as ReturnType<typeof vi.fn>).mockResolvedValue([]);
       await docTools.yuque_list_docs.handler(mockClient, { repo_id: 'user/repo' } as never);
-      expect(mockClient.listDocs).toHaveBeenCalledWith('user/repo');
+      expect(mockClient.listDocs).toHaveBeenCalledWith('user/repo', {
+        offset: undefined,
+        limit: undefined,
+      });
+    });
+
+    it('should pass pagination options through', async () => {
+      (mockClient.listDocs as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+      await docTools.yuque_list_docs.handler(mockClient, {
+        repo_id: 1,
+        offset: 100,
+        limit: 50,
+      } as never);
+      expect(mockClient.listDocs).toHaveBeenCalledWith(1, { offset: 100, limit: 50 });
     });
   });
 
   describe('yuque_get_doc', () => {
-    it('should get doc with YMD-compatible content by default', async () => {
-      (mockClient.getDoc as ReturnType<typeof vi.fn>).mockResolvedValue({
-        id: 1,
-        slug: 'doc1',
-        title: 'Doc 1',
-        body: '# Hello',
-        body_html: '<h1>Hello</h1>',
-        format: 'markdown',
-        created_at: '2024-01-01',
-        updated_at: '2024-01-02',
-        word_count: 100,
-      });
+    it('should read only through the YMD API by default with a numeric doc id', async () => {
       (mockClient.getYmdDoc as ReturnType<typeof vi.fn>).mockResolvedValue({
         doc_id: 1,
         title: 'Doc 1',
@@ -73,11 +74,37 @@ describe('docTools', () => {
       expect(parsed).toHaveProperty('format', 'markdown');
       expect(parsed).toHaveProperty('updated_at', '2024-01-03');
       expect(parsed).not.toHaveProperty('body_lake');
-      expect(mockClient.getDoc).toHaveBeenCalledWith(1, 1);
       expect(mockClient.getYmdDoc).toHaveBeenCalledWith(1);
+      expect(mockClient.getDoc).not.toHaveBeenCalled();
     });
 
-    it('should include body_lake when include_lake is true', async () => {
+    it('should resolve a slug to a numeric id before the YMD read', async () => {
+      (mockClient.getDoc as ReturnType<typeof vi.fn>).mockResolvedValue({
+        id: 7,
+        slug: 'doc-slug',
+        title: 'Doc 7',
+        body: '# Legacy body',
+        format: 'markdown',
+      });
+      (mockClient.getYmdDoc as ReturnType<typeof vi.fn>).mockResolvedValue({
+        doc_id: 7,
+        title: 'Doc 7',
+        url: '/user/repo/doc-slug',
+        yfm: '# Hello from YMD',
+        updated_at: '2024-01-03',
+      });
+      const result = await docTools.yuque_get_doc.handler(mockClient, {
+        repo_id: 'user/repo',
+        doc_id: 'doc-slug',
+        include_lake: false,
+      } as never);
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed).toHaveProperty('body', '# Hello from YMD');
+      expect(mockClient.getDoc).toHaveBeenCalledWith('user/repo', 'doc-slug');
+      expect(mockClient.getYmdDoc).toHaveBeenCalledWith(7);
+    });
+
+    it('should use only the legacy API when include_lake is true', async () => {
       (mockClient.getDoc as ReturnType<typeof vi.fn>).mockResolvedValue({
         id: 1,
         slug: 'doc1',
@@ -90,24 +117,18 @@ describe('docTools', () => {
         updated_at: '2024-01-02',
         word_count: 100,
       });
-      (mockClient.getYmdDoc as ReturnType<typeof vi.fn>).mockResolvedValue({
-        doc_id: 1,
-        title: 'Doc 1',
-        url: '/user/repo/doc1',
-        yfm: '# Hello from YMD',
-        updated_at: '2024-01-03',
-      });
       const result = await docTools.yuque_get_doc.handler(mockClient, {
         repo_id: 1,
         doc_id: 1,
         include_lake: true,
       } as never);
       const parsed = JSON.parse(result.content[0].text);
-      expect(parsed).toHaveProperty('body', '# Hello from YMD');
+      expect(parsed).toHaveProperty('body', '# Hello');
       expect(parsed).toHaveProperty('body_lake', '<!doctype lake><p>Hello</p>');
+      expect(mockClient.getYmdDoc).not.toHaveBeenCalled();
     });
 
-    it('should use legacy doc content when read format is lake', async () => {
+    it('should use only the legacy API when read format is lake', async () => {
       (mockClient.getDoc as ReturnType<typeof vi.fn>).mockResolvedValue({
         id: 1,
         slug: 'doc1',
@@ -229,29 +250,12 @@ describe('docTools', () => {
     });
 
     it.each([undefined, 'markdown'] as const)(
-      'should update markdown body through YMD flow when format is %s',
+      'should update a markdown body only through the YMD API when format is %s',
       async (format) => {
-        (mockClient.getDoc as ReturnType<typeof vi.fn>).mockResolvedValue({
-          id: 1,
-          slug: 'doc1',
-          title: 'Doc 1',
-          body: 'Old content',
-          format: 'markdown',
-          created_at: '2024-01-01',
-          updated_at: '2024-01-02',
-          word_count: 2,
-        });
         (mockClient.updateYmdDoc as ReturnType<typeof vi.fn>).mockResolvedValue({
           doc_id: 1,
           title: 'Doc 1',
           url: '/user/repo/doc1',
-          updated_at: '2024-01-03',
-        });
-        (mockClient.getYmdDoc as ReturnType<typeof vi.fn>).mockResolvedValue({
-          doc_id: 1,
-          title: 'Doc 1',
-          url: '/user/repo/doc1',
-          yfm: '# Updated YMD',
           updated_at: '2024-01-03',
         });
 
@@ -263,66 +267,56 @@ describe('docTools', () => {
         } as never);
 
         const parsed = JSON.parse(result.content[0].text);
-        expect(parsed).toHaveProperty('body', '# Updated YMD');
-        expect(parsed).toHaveProperty('format', 'markdown');
-        expect(mockClient.getDoc).toHaveBeenCalledWith(1, 1);
+        expect(parsed).toMatchObject({
+          id: 1,
+          title: 'Doc 1',
+          url: '/user/repo/doc1',
+          updated_at: '2024-01-03',
+        });
         expect(mockClient.updateYmdDoc).toHaveBeenCalledWith(1, '# Updated YMD');
-        expect(mockClient.getYmdDoc).toHaveBeenCalledWith(1);
+        expect(mockClient.getDoc).not.toHaveBeenCalled();
+        expect(mockClient.getYmdDoc).not.toHaveBeenCalled();
         expect(mockClient.updateDoc).not.toHaveBeenCalled();
       }
     );
 
-    it('should update metadata and markdown body through mixed legacy/YMD flow', async () => {
+    it('should resolve a slug to a numeric id before the YMD write', async () => {
       (mockClient.getDoc as ReturnType<typeof vi.fn>).mockResolvedValue({
-        id: 1,
-        slug: 'doc1',
-        title: 'Doc 1',
-        body: 'Old content',
+        id: 7,
+        slug: 'doc-slug',
+        title: 'Doc 7',
         format: 'markdown',
-        created_at: '2024-01-01',
-        updated_at: '2024-01-02',
-        word_count: 2,
-      });
-      (mockClient.updateDoc as ReturnType<typeof vi.fn>).mockResolvedValue({
-        id: 1,
-        slug: 'doc1',
-        title: 'Updated',
-        body: 'Old content',
-        format: 'markdown',
-        created_at: '2024-01-01',
-        updated_at: '2024-01-03',
-        word_count: 2,
       });
       (mockClient.updateYmdDoc as ReturnType<typeof vi.fn>).mockResolvedValue({
-        doc_id: 1,
-        title: 'Updated',
-        url: '/user/repo/doc1',
-        updated_at: '2024-01-04',
-      });
-      (mockClient.getYmdDoc as ReturnType<typeof vi.fn>).mockResolvedValue({
-        doc_id: 1,
-        title: 'Updated',
-        url: '/user/repo/doc1',
-        yfm: '# Updated YMD',
-        updated_at: '2024-01-04',
+        doc_id: 7,
+        title: 'Doc 7',
+        url: '/user/repo/doc-slug',
+        updated_at: '2024-01-03',
       });
 
-      const result = await docTools.yuque_update_doc.handler(mockClient, {
-        repo_id: 1,
-        doc_id: 1,
-        title: 'Updated',
+      await docTools.yuque_update_doc.handler(mockClient, {
+        repo_id: 'user/repo',
+        doc_id: 'doc-slug',
         body: '# Updated YMD',
       } as never);
 
-      const parsed = JSON.parse(result.content[0].text);
-      expect(parsed).toHaveProperty('title', 'Updated');
-      expect(parsed).toHaveProperty('body', '# Updated YMD');
-      expect(mockClient.updateDoc).toHaveBeenCalledWith(
-        1,
-        1,
-        expect.objectContaining({ title: 'Updated' })
-      );
-      expect(mockClient.updateYmdDoc).toHaveBeenCalledWith(1, '# Updated YMD');
+      expect(mockClient.getDoc).toHaveBeenCalledWith('user/repo', 'doc-slug');
+      expect(mockClient.updateYmdDoc).toHaveBeenCalledWith(7, '# Updated YMD');
+      expect(mockClient.updateDoc).not.toHaveBeenCalled();
+    });
+
+    it('should reject mixed metadata + markdown body updates', async () => {
+      await expect(
+        docTools.yuque_update_doc.handler(mockClient, {
+          repo_id: 1,
+          doc_id: 1,
+          title: 'Updated',
+          body: '# Updated YMD',
+        } as never)
+      ).rejects.toThrow('cannot change title/slug/public in the same call');
+
+      expect(mockClient.updateDoc).not.toHaveBeenCalled();
+      expect(mockClient.updateYmdDoc).not.toHaveBeenCalled();
     });
 
     it('should use legacy doc update when body format is lake', async () => {

--- a/tests/tools/remaining.test.ts
+++ b/tests/tools/remaining.test.ts
@@ -13,9 +13,9 @@ beforeEach(() => vi.clearAllMocks());
 
 describe('searchTools', () => {
   describe('yuque_search', () => {
-    it('should search with query and type', async () => {
+    it('should search and strip highlight markup', async () => {
       (mockClient.search as ReturnType<typeof vi.fn>).mockResolvedValue({
-        items: [{ id: 1, type: 'doc', title: 'Result' }],
+        items: [{ id: 1, type: 'doc', title: '<em>Result</em>', body: 'Some <em>match</em>' }],
         total: 1,
       });
       const result = await searchTools.yuque_search.handler(mockClient, {
@@ -23,13 +23,29 @@ describe('searchTools', () => {
         type: 'doc',
       } as never);
       expect(result.content[0].type).toBe('text');
-      expect(mockClient.search).toHaveBeenCalledWith('test', 'doc');
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed.total).toBe(1);
+      expect(parsed.items[0]).toMatchObject({ title: 'Result', summary: 'Some match' });
+      expect(mockClient.search).toHaveBeenCalledWith('test', 'doc', undefined);
     });
 
-    it('should search with type filter', async () => {
+    it('should pass the page number through', async () => {
       (mockClient.search as ReturnType<typeof vi.fn>).mockResolvedValue({ items: [], total: 0 });
-      await searchTools.yuque_search.handler(mockClient, { query: 'test', type: 'doc' } as never);
-      expect(mockClient.search).toHaveBeenCalledWith('test', 'doc');
+      await searchTools.yuque_search.handler(mockClient, {
+        query: 'test',
+        type: 'doc',
+        page: 2,
+      } as never);
+      expect(mockClient.search).toHaveBeenCalledWith('test', 'doc', 2);
+    });
+
+    it('should return an empty result shape when the API returns nothing', async () => {
+      (mockClient.search as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
+      const result = await searchTools.yuque_search.handler(mockClient, {
+        query: 'test',
+        type: 'doc',
+      } as never);
+      expect(JSON.parse(result.content[0].text)).toEqual({ total: 0, items: [] });
     });
   });
 });

--- a/tests/utils/config.test.ts
+++ b/tests/utils/config.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeYuqueBaseURL, resolveYuqueBaseURL, resolveYuqueToken } from '../../src/config.js';
+
+describe('Yuque runtime config', () => {
+  it('should resolve token with canonical env first and legacy env as fallback', () => {
+    expect(
+      resolveYuqueToken(['node', 'cli.js', '--token=arg-token'], {
+        YUQUE_TOKEN: 'canonical-token',
+        YUQUE_PERSONAL_TOKEN: 'legacy-token',
+      })
+    ).toBe('canonical-token');
+
+    expect(
+      resolveYuqueToken(['node', 'cli.js', '--token=arg-token'], {
+        YUQUE_PERSONAL_TOKEN: 'legacy-token',
+      })
+    ).toBe('legacy-token');
+
+    expect(resolveYuqueToken(['node', 'cli.js', '--token=arg=token'], {})).toBe('arg=token');
+  });
+
+  it('should normalize host values into Yuque API base URLs', () => {
+    expect(normalizeYuqueBaseURL(undefined)).toBeUndefined();
+    expect(normalizeYuqueBaseURL('https://space.yuque.com')).toBe('https://space.yuque.com/api/v2');
+    expect(normalizeYuqueBaseURL('https://space.yuque.com/')).toBe(
+      'https://space.yuque.com/api/v2'
+    );
+    expect(normalizeYuqueBaseURL('https://space.yuque.com/api/v2')).toBe(
+      'https://space.yuque.com/api/v2'
+    );
+  });
+
+  it('should resolve host with canonical env and flag before legacy base URL', () => {
+    expect(
+      resolveYuqueBaseURL(['node', 'cli.js', '--host=https://arg.yuque.com'], {
+        YUQUE_HOST: 'https://env.yuque.com',
+        YUQUE_BASE_URL: 'https://legacy.example/api/v2',
+      })
+    ).toBe('https://env.yuque.com/api/v2');
+
+    expect(resolveYuqueBaseURL(['node', 'cli.js', '--host=https://arg.yuque.com'], {})).toBe(
+      'https://arg.yuque.com/api/v2'
+    );
+
+    expect(
+      resolveYuqueBaseURL(['node', 'cli.js', '--base-url=https://legacy.example/api/v2'], {})
+    ).toBe('https://legacy.example/api/v2');
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
     environment: 'node',
     testTimeout: 10000,
     hookTimeout: 10000,
+    exclude: ['**/node_modules/**', '**/dist/**', '**/.claude/**'],
     coverage: {
       provider: 'v8',
       include: ['src/**/*.ts'],


### PR DESCRIPTION
## 变更概览

架构审查后的一批修复,主要包括:

### Doc 工具按 format 二选一路由
- `yuque_get_doc`:format 省略或 `markdown` 时只走 YMD API(`/yfm/docs`),返回 YMD 视图;`lake`/`html` 或 `include_lake: true` 时只走 legacy document API
- `yuque_update_doc`:markdown body 只走 YMD 写入,不再有更新后的额外读回;纯元数据或 lake/html body 只走 legacy API;markdown body 与 title/slug/public 混合更新会显式报错,引导分两次调用,避免跨链路的部分更新
- YMD API 只接受数字 doc ID,传 slug 时自动做一次 ID 解析

### 移植 feat/trim-yuque-client-surface
- 新增 `src/config.ts` 统一 token/host 解析:支持 `YUQUE_TOKEN` / `YUQUE_HOST`(自动补全 `/api/v2`),并修复 `--token` / `--base-url` 含 `=` 时被截断的解析 bug
- 删除 YuqueClient 中约 15 个无工具对应的方法和 4 个无用类型
- 修正 `server.json` 清单(此前声明了代码不读取的环境变量、版本停留在 0.1.4),新增 manifest 契约测试

### HTTP 入口会话与安全
- 每个 MCP session 独立一对 transport + server(initialize 创建、关闭清理),修复单 transport 全局共享导致的多客户端会话冲突
- 默认只绑定 `127.0.0.1` 并开启 DNS rebinding 防护;设置 `HOST` 可显式暴露(防护随之关闭,文档已注明需自行加认证)

### 工具细节
- `yuque_list_docs` / `yuque_list_books` 支持 `offset` / `limit` 分页;`yuque_search` 支持 `page`
- `yuque_list_books` 的 `login` 改为可选,省略时取当前用户
- search 结果剥离 `<em>` 高亮标签并精简为 `{total, items}` 结构
- note 更新时对 HTML 包装做字符转义

### 其他
- `.gitignore` / vitest 排除 `.claude/`,本地测试不再混入旧 worktree 拷贝
- 同步 `docs/capability-scope.md`、`docs/core-architecture.md`、`docs/technical-stack.md` 与契约测试

## 验证
- `npm run lint` / `npm run typecheck` / `npm run format:check` 全部通过
- `npx vitest run`:182 passed | 3 skipped
- `npm run build` + `npm run smoke:dist` + `npm run smoke:pack-install` 全部通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)