### PR TITLE
feat: tool scaffold and structured requirement intake

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -22,6 +22,17 @@ body:
       required: true
 
   - type: textarea
+    id: acceptance-criteria
+    attributes:
+      label: Acceptance Criteria
+      description: How do we know this is done? Prefer verifiable statements — expected behavior, example calls and outputs, checks that must pass.
+      placeholder: |
+        - yuque_get_doc with include_lake=true returns the raw Lake body
+        - Contract tests and docs/capability-scope.md updated; npm run check passes
+    validations:
+      required: false
+
+  - type: textarea
     id: alternatives
     attributes:
       label: Alternatives Considered

--- a/.github/ISSUE_TEMPLATE/tool_request.yml
+++ b/.github/ISSUE_TEMPLATE/tool_request.yml
@@ -1,0 +1,64 @@
+name: Tool Request
+description: Request a new MCP tool with a structured spec that can be delivered directly
+title: "[Tool] yuque_"
+labels: ["enhancement"]
+body:
+  - type: input
+    id: tool-name
+    attributes:
+      label: Tool Name
+      description: Follow `yuque_<verb>_<resource>`, consistent with existing names in docs/capability-scope.md
+      placeholder: yuque_list_comments
+    validations:
+      required: true
+
+  - type: input
+    id: api-endpoint
+    attributes:
+      label: Yuque API Endpoint
+      description: The upstream API this tool wraps (HTTP method + path)
+      placeholder: GET /repos/{repo_id}/docs/{doc_id}/comments
+    validations:
+      required: true
+
+  - type: dropdown
+    id: access-type
+    attributes:
+      label: Access Type
+      options:
+        - Read only
+        - Write (creates or updates data)
+    validations:
+      required: true
+
+  - type: textarea
+    id: parameters
+    attributes:
+      label: Parameters
+      description: Each parameter with type, required/optional, and any enum values or defaults
+      placeholder: |
+        - repo_id (string, required): repo id or namespace
+        - doc_id (string, required): doc id or slug
+        - page (number, optional, default 1)
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance-criteria
+    attributes:
+      label: Acceptance Criteria
+      description: Verifiable statements that define done — expected behavior, example calls and outputs
+      placeholder: |
+        - tools/list exposes the tool with the schema above
+        - Calling it with repo_id=X and doc_id=Y returns the comment list as formatted JSON
+        - Contract tests and docs/capability-scope.md updated; npm run check passes
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: scope-check
+    attributes:
+      label: Scope Check
+      options:
+        - label: I checked the "Out of Scope" list in docs/capability-scope.md — this capability is not deliberately excluded, or this request explicitly proposes changing that boundary
+          required: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,6 @@ npm test            # 单跑全量测试，单次运行（watch 用 npm run test
 
 执行常见变更前，先读 `docs/workflows/` 下对应的步骤文档：
 
-- 新增 MCP tool: `docs/workflows/add-tool.md`
+- 新增 MCP tool: `docs/workflows/add-tool.md`（可先跑 `npm run new:tool -- <domain> <yuque_tool_name>` 生成骨架）
 - 修改现有 tool 参数或行为: `docs/workflows/modify-tool.md`
 - 修复 bug: `docs/workflows/fix-bug.md`

--- a/docs/technical-stack.md
+++ b/docs/technical-stack.md
@@ -37,6 +37,7 @@
 - `eslint`: TypeScript lint。
 - `prettier`: 代码格式化。
 - `conventional-changelog-cli`: 生成 changelog。
+- `scripts/new-tool.js`: `npm run new:tool -- <domain> <yuque_tool_name>` 生成新 tool 骨架和步骤清单。
 
 ## Test Layers
 

--- a/docs/workflows/add-tool.md
+++ b/docs/workflows/add-tool.md
@@ -4,8 +4,9 @@
 
 ## 0. 前置确认
 
-- 明确 tool 名称、参数和返回值。命名遵循 `yuque_<动词>_<资源>`，参考 [capability-scope.md](../capability-scope.md) 中现有 tool 的命名。
+- 明确 tool 名称、参数和返回值。命名遵循 `yuque_<动词>_<资源>`，参考 [capability-scope.md](../capability-scope.md) 中现有 tool 的命名。需求来自 issue 时，优先使用 Tool Request 模板里的结构化字段（tool 名、API endpoint、参数表、验收标准）作为规格。
 - 确认该能力不在 capability-scope.md 的 "Out of Scope" 清单里；如果在，先和维护者确认是否调整边界，不要直接实现。
+- 可用脚手架生成骨架并打印剩余步骤清单：`npm run new:tool -- <domain> <yuque_tool_name>`。新 domain 会生成 tool 文件和占位测试；已有 domain 会打印待粘贴的代码片段，不改动现有文件。
 
 ## 1. Service 层：封装语雀 API
 

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "build": "tsc && chmod +x dist/cli.js",
     "check": "npm run lint && npm run format:check && npm run typecheck && npm test && npm run build",
     "dev": "tsx watch src/cli.ts",
+    "new:tool": "node scripts/new-tool.js",
     "smoke:dist": "node scripts/smoke-dist-cli.js",
     "smoke:pack-install": "node scripts/smoke-packed-install.js",
     "test": "vitest run",

--- a/scripts/new-tool.js
+++ b/scripts/new-tool.js
@@ -1,0 +1,114 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(scriptDir, '..');
+
+function fail(message) {
+  console.error(`error: ${message}`);
+  console.error('');
+  console.error('usage:   npm run new:tool -- <domain> <yuque_tool_name>');
+  console.error('example: npm run new:tool -- comment yuque_list_comments');
+  process.exit(1);
+}
+
+const [domain, toolName] = process.argv.slice(2);
+
+if (!domain || !toolName) fail('missing arguments');
+if (!/^[a-z]+$/.test(domain)) {
+  fail(`domain "${domain}" must be a single lowercase word (like doc, book, note)`);
+}
+if (!/^yuque_[a-z][a-z_]*$/.test(toolName)) {
+  fail(`tool name "${toolName}" must follow yuque_<verb>_<resource> in lowercase`);
+}
+
+const toolsDir = path.join(repoRoot, 'src', 'tools');
+const toolFile = path.join(toolsDir, `${domain}.ts`);
+const testFile = path.join(repoRoot, 'tests', 'tools', `${domain}.test.ts`);
+const toolsVar = `${domain}Tools`;
+
+for (const existing of fs.readdirSync(toolsDir)) {
+  const content = fs.readFileSync(path.join(toolsDir, existing), 'utf8');
+  if (content.includes(`${toolName}:`)) {
+    fail(`${toolName} already exists in src/tools/${existing}`);
+  }
+}
+
+const toolStub = `  ${toolName}: {
+    description: 'TODO: describe what this tool does and its key parameters',
+    inputSchema: z.object({}),
+    handler: async (_client: YuqueClient, _args: Record<string, never>) => {
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: 'TODO: implement ${toolName} (see docs/workflows/add-tool.md)',
+          },
+        ],
+      };
+    },
+  },
+`;
+
+const toolFileContent = `import { z } from 'zod';
+import type { YuqueClient } from '../services/yuque-client.js';
+
+export const ${toolsVar} = {
+${toolStub}};
+`;
+
+const testFileContent = `import { describe, it, expect } from 'vitest';
+import { ${toolsVar} } from '../../src/tools/${domain}.js';
+import type { YuqueClient } from '../../src/services/yuque-client.js';
+
+describe('${toolsVar}', () => {
+  describe('${toolName}', () => {
+    it('should be implemented (replace this placeholder with real assertions)', async () => {
+      const result = await ${toolsVar}.${toolName}.handler({} as YuqueClient, {} as never);
+
+      expect(result.content[0].type).toBe('text');
+    });
+  });
+});
+`;
+
+const created = [];
+const domainExists = fs.existsSync(toolFile);
+
+if (domainExists) {
+  console.log(`src/tools/${domain}.ts already exists — not modifying it.`);
+  console.log(`Paste this into the ${toolsVar} object yourself:`);
+  console.log('');
+  console.log(toolStub);
+} else {
+  fs.writeFileSync(toolFile, toolFileContent);
+  created.push(`src/tools/${domain}.ts`);
+  if (fs.existsSync(testFile)) {
+    console.log(`tests/tools/${domain}.test.ts already exists — not modifying it.`);
+  } else {
+    fs.writeFileSync(testFile, testFileContent);
+    created.push(`tests/tools/${domain}.test.ts`);
+  }
+}
+
+if (created.length > 0) {
+  console.log('Created:');
+  for (const file of created) console.log(`  ${file}`);
+  console.log('');
+}
+
+console.log(`Next steps for ${toolName} (full recipe: docs/workflows/add-tool.md):`);
+console.log('  1. Add the API method and types in src/services/yuque-client.ts and src/services/types.ts');
+console.log(`  2. Implement the real inputSchema and handler in src/tools/${domain}.ts`);
+if (!domainExists) {
+  console.log(`  3. Register the new domain in src/server.ts: spread ...${toolsVar} into allTools`);
+} else {
+  console.log('  3. (domain already registered in src/server.ts — nothing to do)');
+}
+console.log(`  4. Replace the placeholder test in tests/tools/${domain}.test.ts with real assertions`);
+console.log('  5. Pin the contract: add the tool to expectedToolNames and requiredFieldsByTool in');
+console.log('     tests/mcp/tool-registry-contract.test.ts, and cover it in tests/mcp/tool-call-contract.test.ts');
+console.log('  6. Document it in docs/capability-scope.md: summary table, domain section,');
+console.log('     and every "N 个 MCP tools" count (a contract test verifies this)');
+console.log('  7. npm run check must pass before you open the PR');


### PR DESCRIPTION
## Summary

Stacked on #80 (which is stacked on #79 — merge in order). Third batch of harness building: converts the two remaining judgment-heavy spots in the delivery pipeline into procedure.

- **`npm run new:tool -- <domain> <yuque_tool_name>`**: scaffolds a gate-passing tool stub + placeholder test for new domains; for existing domains prints a paste-ready snippet without touching the file; rejects duplicate tool names and malformed args; always prints the remaining delivery checklist mirroring `docs/workflows/add-tool.md`. The add-tool recipe goes from "document the agent must follow" to "procedure the harness executes".
- **Structured requirement intake**: new Tool Request issue template captures a directly deliverable spec — tool name, upstream Yuque endpoint, access type, parameter table, required acceptance criteria, and a mandatory out-of-scope check against `docs/capability-scope.md`. Feature Request gains an optional acceptance criteria field.

## Test plan

- [x] Scaffold new domain: creates `src/tools/demo.ts` + `tests/tools/demo.test.ts`; full `npm run check` green with generated stubs in place (185 tests)
- [x] Existing domain: prints snippet, `git status` confirms no file modified
- [x] Duplicate tool name (`yuque_get_doc`): rejected with file location
- [x] Malformed domain (`Demo`): rejected with usage guidance
- [x] Demo files removed; final tree contains only intended changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)