### PR TITLE
docs: rewrite READMEs as product-first docs and lock tool surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,69 +2,40 @@
 
 [![CI](https://github.com/yuque/yuque-mcp-server/actions/workflows/ci.yml/badge.svg)](https://github.com/yuque/yuque-mcp-server/actions/workflows/ci.yml)
 [![npm version](https://img.shields.io/npm/v/yuque-mcp)](https://www.npmjs.com/package/yuque-mcp)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![npm downloads](https://img.shields.io/npm/dm/yuque-mcp)](https://www.npmjs.com/package/yuque-mcp)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](./LICENSE)
 
-MCP server for [Yuque (语雀)](https://www.yuque.com/) — expose your knowledge base to AI assistants through the [Model Context Protocol](https://modelcontextprotocol.io/).
+Let AI assistants read and write your [Yuque (语雀)](https://www.yuque.com/) knowledge base through the [Model Context Protocol](https://modelcontextprotocol.io/).
 
-🌐 **[Website](https://yuque.github.io/yuque-ecosystem/)** · 📖 [API Docs](https://www.yuque.com/yuque/developer/api) · [中文文档](./README.zh-CN.md)
+[中文文档](./README.zh-CN.md)
 
----
+Once connected, ask your assistant things like:
+
+> "Search my Yuque for everything about canary releases and give me a one-page summary."
+>
+> "Turn today's meeting notes into a doc in my _Tech Research_ book."
+>
+> "Add a flowchart of this deployment pipeline to the design doc."
 
 ## Quick Start
 
-### 1. Get Your Yuque API Token
+**1. Get a token.** Create one at [Yuque Developer Settings](https://www.yuque.com/settings/tokens). If you use a team token bound to a Yuque space, also note the space host (for example `https://your-space.yuque.com`) — you will pass it as `--host`.
 
-Visit [Yuque Developer Settings](https://www.yuque.com/settings/tokens) to create a personal access token.
-If you use a team token from a Yuque space, also prepare that space host, for example `https://your-space.yuque.com`.
-
-### 2. Quick Install (Recommended)
-
-Use the built-in CLI to auto-configure your MCP client in one command:
+**2. Install.** One command configures your client:
 
 ```bash
 npx yuque-mcp install --token=YOUR_TOKEN --client=cursor
 ```
 
-Supported clients: `claude-desktop`, `vscode`, `cursor`, `windsurf`, `cline`, `trae`, `qoder`, `opencode`
+Supported clients: `claude-desktop`, `vscode`, `cursor`, `windsurf`, `cline`, `trae`, `qoder`, `opencode`. The installer locates the right config file for your OS and merges a `yuque` entry into it without touching other servers. Prefer an interactive flow? Run `npx yuque-mcp setup`.
 
-Or use the interactive setup wizard:
-
-```bash
-npx yuque-mcp setup
-```
-
-The CLI will automatically find the correct config file for your OS, merge with any existing configuration (without overwriting other servers), and print a success message.
-
-### 3. Manual Configuration
-
-<details>
-<summary>Prefer to configure manually? Click to expand all client configs.</summary>
-
-Choose your preferred client below:
-
-<details open>
-<summary><b>Claude Code</b></summary>
+Using Claude Code? Register the server directly:
 
 ```bash
-claude mcp add yuque-mcp -- npx -y yuque-mcp --token=YOUR_TOKEN
+claude mcp add yuque -- npx -y yuque-mcp --token=YOUR_TOKEN
 ```
 
-Or using environment variables:
-
-```bash
-export YUQUE_TOKEN=YOUR_TOKEN
-claude mcp add yuque-mcp -- npx -y yuque-mcp
-```
-
-</details>
-
-<details>
-<summary><b>Claude Desktop</b></summary>
-
-Add to your `claude_desktop_config.json`:
-
-- macOS: `~/Library/Application Support/Claude/claude_desktop_config.json`
-- Windows: `%APPDATA%\Claude\claude_desktop_config.json`
+Any other MCP client that supports stdio transport works too — see [docs/clients.md](./docs/clients.md) for per-client config paths, or use the generic entry:
 
 ```json
 {
@@ -72,187 +43,75 @@ Add to your `claude_desktop_config.json`:
     "yuque": {
       "command": "npx",
       "args": ["-y", "yuque-mcp"],
-      "env": {
-        "YUQUE_TOKEN": "YOUR_TOKEN"
-      }
+      "env": { "YUQUE_TOKEN": "YOUR_TOKEN" }
     }
   }
 }
 ```
 
-</details>
+**3. Restart your client** and start asking.
 
-<details>
-<summary><b>VS Code (GitHub Copilot)</b></summary>
+## Configuration
 
-Add to `.vscode/mcp.json` in your workspace:
-
-```json
-{
-  "servers": {
-    "yuque": {
-      "command": "npx",
-      "args": ["-y", "yuque-mcp"],
-      "env": {
-        "YUQUE_TOKEN": "YOUR_TOKEN"
-      }
-    }
-  }
-}
-```
-
-Then enable Agent mode in GitHub Copilot Chat.
-
-</details>
-
-<details>
-<summary><b>Cursor</b></summary>
-
-Add to your Cursor MCP configuration (`~/.cursor/mcp.json`):
-
-```json
-{
-  "mcpServers": {
-    "yuque": {
-      "command": "npx",
-      "args": ["-y", "yuque-mcp"],
-      "env": {
-        "YUQUE_TOKEN": "YOUR_TOKEN"
-      }
-    }
-  }
-}
-```
-
-</details>
-
-<details>
-<summary><b>Windsurf</b></summary>
-
-Add to your Windsurf MCP configuration (`~/.windsurf/mcp.json`):
-
-```json
-{
-  "mcpServers": {
-    "yuque": {
-      "command": "npx",
-      "args": ["-y", "yuque-mcp"],
-      "env": {
-        "YUQUE_TOKEN": "YOUR_TOKEN"
-      }
-    }
-  }
-}
-```
-
-</details>
-
-<details>
-<summary><b>Cline (VS Code)</b></summary>
-
-Add to your Cline MCP settings (`~/Library/Application Support/Code/User/globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json`):
-
-```json
-{
-  "mcpServers": {
-    "yuque": {
-      "command": "npx",
-      "args": ["-y", "yuque-mcp"],
-      "env": {
-        "YUQUE_TOKEN": "YOUR_TOKEN"
-      }
-    }
-  }
-}
-```
-
-</details>
-
-<details>
-<summary><b>Trae</b></summary>
-
-In Trae, open **Settings** and navigate to the **MCP** section, then add a new stdio-type MCP Server with the following configuration:
-
-- **Command:** `npx`
-- **Args:** `-y yuque-mcp`
-- **Env:** `YUQUE_TOKEN=YOUR_TOKEN`
-
-See [Trae MCP documentation](https://docs.trae.ai/ide/model-context-protocol) for detailed instructions.
-
-</details>
-
-> **More clients:** Any MCP-compatible client that supports stdio transport can use yuque-mcp. The general pattern is: command = `npx`, args = `["-y", "yuque-mcp"]`, env = `YUQUE_TOKEN`.
-
-</details>
-
-### 4. Done!
-
-Ask your AI assistant to search your Yuque docs, create documents, or manage books.
-
----
-
-## Authentication
-
-The server supports multiple ways to provide your Yuque API token:
-
-| Method | Environment Variable / Flag | Description |
-|--------|---------------------------|-------------|
-| **Token** | `YUQUE_TOKEN` | Personal or team Yuque API token |
-| **Host** | `YUQUE_HOST` / `--host=https://your-space.yuque.com` | Yuque site or space host; required for team tokens tied to a specific space |
-| **CLI Argument** | `--token=YOUR_TOKEN` | Pass directly as a command-line argument |
-
-**Token priority order:** `YUQUE_TOKEN` > `YUQUE_PERSONAL_TOKEN` > `--token`
-
-**Host priority order:** `YUQUE_HOST` > `--host` > `YUQUE_BASE_URL` > `--base-url`
-
-`YUQUE_PERSONAL_TOKEN`, `YUQUE_BASE_URL`, and `--base-url` are kept as legacy fallbacks for existing configs. New configs should use `YUQUE_TOKEN` and `YUQUE_HOST`.
-
-### Team Tokens and Private Deployment
-
-For team tokens, privately deployed Yuque instances, or custom Yuque spaces, set `YUQUE_HOST` or pass `--host`:
+| Setting          | Env var / CLI flag        | Description                                                                                                                                                                                                                              |
+| ---------------- | ------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Token (required) | `YUQUE_TOKEN` / `--token` | Personal or team Yuque API token.                                                                                                                                                                                                        |
+| Host (optional)  | `YUQUE_HOST` / `--host`   | Yuque site or space host, e.g. `https://your-space.yuque.com`. Required for team tokens bound to a space and for private deployments. Site roots are normalized to `/api/v2`; defaults to `https://www.yuque.com/api/v2` when not set. |
 
 ```bash
-# Environment variable
-export YUQUE_TOKEN=YOUR_TOKEN
-export YUQUE_HOST=https://your-space.yuque.com
-
-# CLI argument
-npx yuque-mcp --token=YOUR_TOKEN --host=https://your-space.yuque.com
-
-# Install with custom host
+# Team token / private deployment
 npx yuque-mcp install --token=YOUR_TOKEN --client=cursor --host=https://your-space.yuque.com
 ```
 
-The host may be a Yuque site root such as `https://www.yuque.com` or a full API base URL such as `https://www.yuque.com/api/v2`. Host roots are normalized to `/api/v2` at runtime. When not set, the default API base URL is `https://www.yuque.com/api/v2`.
+<details>
+<summary>Migrating from an older config?</summary>
 
----
+`YUQUE_PERSONAL_TOKEN`, `YUQUE_BASE_URL`, and `--base-url` still work as legacy fallbacks. Precedence: `YUQUE_TOKEN` > `YUQUE_PERSONAL_TOKEN` > `--token`, and `YUQUE_HOST` > `--host` > `YUQUE_BASE_URL` > `--base-url`. New configs should use `YUQUE_TOKEN` and `YUQUE_HOST`.
 
-## Available Tools (19)
+</details>
 
-| Category | Tools |
-|----------|-------|
-| **User** | `yuque_get_user` |
-| **Search** | `yuque_search` |
-| **Books** | `yuque_list_books`, `yuque_get_book`, `yuque_create_book`, `yuque_update_book` |
-| **Docs** | `yuque_list_docs`, `yuque_get_doc`, `yuque_create_doc`, `yuque_update_doc` |
-| **Resources** | `yuque_get_resource`, `yuque_create_resource`, `yuque_update_resource` |
-| **TOC** | `yuque_get_toc`, `yuque_update_toc` |
-| **Notes** | `yuque_list_notes`, `yuque_get_note`, `yuque_create_note`, `yuque_update_note` |
+## Tools (19)
 
----
+| Category  | Tool                    | What it does                                                                 |
+| --------- | ----------------------- | ---------------------------------------------------------------------------- |
+| User      | `yuque_get_user`        | Get the authenticated user for the current token.                            |
+| Search    | `yuque_search`          | Search docs or repos (`type`: `doc` / `repo`), with optional paging.         |
+| Books     | `yuque_list_books`      | List books (知识库) of a user; defaults to the current user.                 |
+|           | `yuque_get_book`        | Get a book by ID or namespace.                                               |
+|           | `yuque_create_book`     | Create a book.                                                               |
+|           | `yuque_update_book`     | Update a book's name, slug, description, or visibility.                      |
+| Docs      | `yuque_list_docs`       | List docs in a book, with paging (max 100 per page).                         |
+|           | `yuque_get_doc`         | Get a doc with full content — markdown by default, `lake` / `html` on request. |
+|           | `yuque_create_doc`      | Create a doc in a book.                                                      |
+|           | `yuque_update_doc`      | Update a doc's body or metadata.                                             |
+| TOC       | `yuque_get_toc`         | Get a book's table of contents.                                              |
+|           | `yuque_update_toc`      | Apply a single TOC operation (append or move a node).                        |
+| Notes     | `yuque_list_notes`      | List your notes (小记), with paging and status filter.                       |
+|           | `yuque_get_note`        | Get a note with full content.                                                |
+|           | `yuque_create_note`     | Create a note.                                                               |
+|           | `yuque_update_note`     | Update a note.                                                               |
+| Resources | `yuque_get_resource`    | Read a board (mindmap / flowchart / architecture diagram) from a doc.        |
+|           | `yuque_create_resource` | Create a board in a doc.                                                     |
+|           | `yuque_update_resource` | Update a board in a doc.                                                     |
+
+Each call uses exactly one Yuque API route. In particular, `yuque_update_doc` cannot combine a markdown body with `title` / `slug` / `public` changes in a single call — update metadata separately. The full contract, including format routing between the YMD markdown API and the legacy document API, is documented in [docs/capability-scope.md](./docs/capability-scope.md).
+
+**Not covered (yet):** comments, attachment upload and file management, permission and member management, section-level doc edits, and structured resources other than boards.
+
+## Write access
+
+The create/update tools modify real content in your knowledge base, and the server can do whatever your token can do. Keep the token secret, and prefer a space-scoped team token (with `YUQUE_HOST`) when you only work within one space. To report a vulnerability, see [SECURITY.md](./SECURITY.md).
 
 ## Troubleshooting
 
-| Error | Solution |
-|-------|----------|
-| `YUQUE_TOKEN ... is required` | Set `YUQUE_TOKEN=YOUR_TOKEN` or pass `--token=YOUR_TOKEN` |
-| `401 Unauthorized` | Token is invalid or expired — regenerate at [Yuque Settings](https://www.yuque.com/settings/tokens) |
-| `429 Rate Limited` | Too many requests — wait a moment and retry |
-| `410 Gone` | The resource has been permanently deleted or the API endpoint is deprecated — verify the target document/repo still exists |
-| Tool not found | Update to the latest version: `npx -y yuque-mcp@latest` |
-| `npx` command not found | Install [Node.js](https://nodejs.org/) (v18 or later) |
-
----
+| Error                         | Solution                                                                                                             |
+| ----------------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| `YUQUE_TOKEN ... is required` | Set `YUQUE_TOKEN=YOUR_TOKEN` or pass `--token=YOUR_TOKEN`.                                                            |
+| `401 Unauthorized`            | Token is invalid or expired — regenerate at [Yuque Settings](https://www.yuque.com/settings/tokens).                  |
+| `429 Rate Limited`            | Too many requests — wait a moment and retry.                                                                          |
+| `410 Gone`                    | The resource has been permanently deleted or the API endpoint is deprecated — verify the target doc/book still exists. |
+| Tool not found                | Update to the latest version: `npx -y yuque-mcp@latest`.                                                              |
+| `npx` command not found       | Install [Node.js](https://nodejs.org/) (v18 or later).                                                                |
 
 ## Development
 
@@ -265,15 +124,13 @@ npm run build         # compile TypeScript
 npm run dev           # dev mode with hot reload
 ```
 
----
+Architecture, tech stack, and the full tool contract live in [docs/](./docs/README.md). Contributions are welcome — see [CONTRIBUTING.md](./CONTRIBUTING.md).
 
 ## Links
 
-- [Website](https://yuque.github.io/yuque-ecosystem/)
-- [Yuque API Docs](https://www.yuque.com/yuque/developer/api)
-- [MCP Protocol](https://modelcontextprotocol.io/)
-- [MCP Registry](https://github.com/modelcontextprotocol/servers)
-- [Contributing](./CONTRIBUTING.md)
+- [Yuque API docs](https://www.yuque.com/yuque/developer/api)
+- [Model Context Protocol](https://modelcontextprotocol.io/)
+- [Yuque AI Ecosystem](https://yuque.github.io/yuque-ecosystem/) — skills and plugins built on top of this server
 
 ## License
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -2,68 +2,40 @@
 
 [![CI](https://github.com/yuque/yuque-mcp-server/actions/workflows/ci.yml/badge.svg)](https://github.com/yuque/yuque-mcp-server/actions/workflows/ci.yml)
 [![npm version](https://img.shields.io/npm/v/yuque-mcp)](https://www.npmjs.com/package/yuque-mcp)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![npm downloads](https://img.shields.io/npm/dm/yuque-mcp)](https://www.npmjs.com/package/yuque-mcp)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](./LICENSE)
 
-[语雀](https://www.yuque.com/) MCP Server — 通过 [Model Context Protocol](https://modelcontextprotocol.io/) 让 AI 助手访问你的语雀知识库。
+让 Claude、Cursor 等 AI 助手通过 [Model Context Protocol](https://modelcontextprotocol.io/) 直接读写你的[语雀](https://www.yuque.com/)知识库。
 
-🌐 **[官网](https://yuque.github.io/yuque-ecosystem/)** · 📖 [API 文档](https://www.yuque.com/yuque/developer/api) · [English](./README.md)
+[English](./README.md)
 
----
+接入之后，你可以直接对 AI 助手说：
+
+> 「搜一下我语雀里所有关于灰度发布的文档，给我一页总结」
+>
+> 「把今天的会议记录整理成文档，存到『技术调研』知识库」
+>
+> 「给这篇设计文档加一张部署流程图」
 
 ## 快速开始
 
-### 1. 获取语雀 API Token
+**第一步：获取 Token。**前往[语雀开发者设置](https://www.yuque.com/settings/tokens)创建个人访问令牌。如果使用绑定空间的团队 Token，记下空间地址（例如 `https://your-space.yuque.com`），稍后作为 `--host` 传入。
 
-前往 [语雀开发者设置](https://www.yuque.com/settings/tokens) 创建个人访问令牌。如果使用空间里的团队 Token，也准备对应空间的 host，例如 `https://your-space.yuque.com`。
-
-### 2. 快速安装（推荐）
-
-使用内置 CLI 命令一键配置 MCP 客户端：
+**第二步：一键安装。**一条命令完成客户端配置：
 
 ```bash
 npx yuque-mcp install --token=YOUR_TOKEN --client=cursor
 ```
 
-支持的客户端：`claude-desktop`、`vscode`、`cursor`、`windsurf`、`cline`、`trae`、`qoder`、`opencode`
+支持的客户端：`claude-desktop`、`vscode`、`cursor`、`windsurf`、`cline`、`trae`、`qoder`、`opencode`。安装器会自动定位当前操作系统下的配置文件，把 `yuque` 条目合并进去，不影响已有的其他 server。想要问答式引导？运行 `npx yuque-mcp setup`。
 
-或使用交互式安装向导：
-
-```bash
-npx yuque-mcp setup
-```
-
-CLI 会自动找到对应操作系统的配置文件路径，与已有配置合并（不会覆盖其他服务器），并打印成功信息。
-
-### 3. 手动配置
-
-<details>
-<summary>偏好手动配置？点击展开所有客户端配置。</summary>
-
-选择你使用的客户端：
-
-<details open>
-<summary><b>Claude Code</b></summary>
+Claude Code 用户直接注册：
 
 ```bash
-claude mcp add yuque-mcp -- npx -y yuque-mcp --token=YOUR_TOKEN
+claude mcp add yuque -- npx -y yuque-mcp --token=YOUR_TOKEN
 ```
 
-或使用环境变量：
-
-```bash
-export YUQUE_TOKEN=YOUR_TOKEN
-claude mcp add yuque-mcp -- npx -y yuque-mcp
-```
-
-</details>
-
-<details>
-<summary><b>Claude Desktop</b></summary>
-
-添加到 `claude_desktop_config.json`：
-
-- macOS：`~/Library/Application Support/Claude/claude_desktop_config.json`
-- Windows：`%APPDATA%\Claude\claude_desktop_config.json`
+其他支持 stdio 传输的 MCP 客户端也都可以接入——各客户端的配置文件路径见 [docs/clients.md](./docs/clients.md)，通用配置如下：
 
 ```json
 {
@@ -71,186 +43,75 @@ claude mcp add yuque-mcp -- npx -y yuque-mcp
     "yuque": {
       "command": "npx",
       "args": ["-y", "yuque-mcp"],
-      "env": {
-        "YUQUE_TOKEN": "YOUR_TOKEN"
-      }
+      "env": { "YUQUE_TOKEN": "YOUR_TOKEN" }
     }
   }
 }
 ```
 
-</details>
+**第三步：重启客户端**，开始使用。
 
-<details>
-<summary><b>VS Code (GitHub Copilot)</b></summary>
+## 配置
 
-添加到工作区的 `.vscode/mcp.json`：
-
-```json
-{
-  "servers": {
-    "yuque": {
-      "command": "npx",
-      "args": ["-y", "yuque-mcp"],
-      "env": {
-        "YUQUE_TOKEN": "YOUR_TOKEN"
-      }
-    }
-  }
-}
-```
-
-然后在 GitHub Copilot Chat 中启用 Agent 模式。
-
-</details>
-
-<details>
-<summary><b>Cursor</b></summary>
-
-添加到 Cursor MCP 配置（`~/.cursor/mcp.json`）：
-
-```json
-{
-  "mcpServers": {
-    "yuque": {
-      "command": "npx",
-      "args": ["-y", "yuque-mcp"],
-      "env": {
-        "YUQUE_TOKEN": "YOUR_TOKEN"
-      }
-    }
-  }
-}
-```
-
-</details>
-
-<details>
-<summary><b>Windsurf</b></summary>
-
-添加到 Windsurf MCP 配置（`~/.windsurf/mcp.json`）：
-
-```json
-{
-  "mcpServers": {
-    "yuque": {
-      "command": "npx",
-      "args": ["-y", "yuque-mcp"],
-      "env": {
-        "YUQUE_TOKEN": "YOUR_TOKEN"
-      }
-    }
-  }
-}
-```
-
-</details>
-
-<details>
-<summary><b>Cline (VS Code)</b></summary>
-
-添加到 Cline MCP 配置（`~/Library/Application Support/Code/User/globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json`）：
-
-```json
-{
-  "mcpServers": {
-    "yuque": {
-      "command": "npx",
-      "args": ["-y", "yuque-mcp"],
-      "env": {
-        "YUQUE_TOKEN": "YOUR_TOKEN"
-      }
-    }
-  }
-}
-```
-
-</details>
-
-<details>
-<summary><b>Trae</b></summary>
-
-在 Trae 中，打开 **设置**，进入 **MCP** 部分，添加一个 stdio 类型的 MCP Server，配置如下：
-
-- **Command:** `npx`
-- **Args:** `-y yuque-mcp`
-- **Env:** `YUQUE_TOKEN=YOUR_TOKEN`
-
-详见 [Trae MCP 文档](https://docs.trae.ai/ide/model-context-protocol)。
-
-</details>
-
-> **更多客户端：** 任何支持 stdio 传输的 MCP 客户端均可使用 yuque-mcp。通用配置：command = `npx`，args = `["-y", "yuque-mcp"]`，env = `YUQUE_TOKEN`。
-
-</details>
-
-### 4. 开始使用！
-
-让 AI 助手搜索语雀文档、创建文档、管理知识库。
-
----
-
-## 认证方式
-
-服务器支持多种方式提供语雀 API Token：
-
-| 方式 | 环境变量 / 参数 | 说明 |
-|------|----------------|------|
-| **Token** | `YUQUE_TOKEN` | 个人或团队语雀 API Token |
-| **Host** | `YUQUE_HOST` / `--host=https://your-space.yuque.com` | 语雀站点或空间 host；使用绑定空间的团队 Token 时必须设置 |
-| **CLI 参数** | `--token=YOUR_TOKEN` | 通过命令行参数传入 |
-
-**Token 优先级：** `YUQUE_TOKEN` > `YUQUE_PERSONAL_TOKEN` > `--token`
-
-**Host 优先级：** `YUQUE_HOST` > `--host` > `YUQUE_BASE_URL` > `--base-url`
-
-`YUQUE_PERSONAL_TOKEN`、`YUQUE_BASE_URL` 和 `--base-url` 继续作为旧配置的兼容 fallback。新配置建议使用 `YUQUE_TOKEN` 和 `YUQUE_HOST`。
-
-### 团队 Token 与私有化部署
-
-如果使用团队 Token、私有化部署实例或自定义语雀空间，设置 `YUQUE_HOST` 环境变量或使用 `--host` CLI 参数：
+| 配置项        | 环境变量 / CLI 参数       | 说明                                                                                                                                                                                       |
+| ------------- | ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Token（必填） | `YUQUE_TOKEN` / `--token` | 个人或团队语雀 API Token。                                                                                                                                                                 |
+| Host（可选）  | `YUQUE_HOST` / `--host`   | 语雀站点或空间地址，例如 `https://your-space.yuque.com`。绑定空间的团队 Token 和私有化部署必须设置。站点根地址会自动规范化为 `/api/v2`，不设置时默认 `https://www.yuque.com/api/v2`。 |
 
 ```bash
-# 环境变量
-export YUQUE_TOKEN=YOUR_TOKEN
-export YUQUE_HOST=https://your-space.yuque.com
-
-# CLI 参数
-npx yuque-mcp --token=YOUR_TOKEN --host=https://your-space.yuque.com
-
-# 安装时指定
+# 团队 Token / 私有化部署
 npx yuque-mcp install --token=YOUR_TOKEN --client=cursor --host=https://your-space.yuque.com
 ```
 
-`YUQUE_HOST` 可以是语雀站点根地址，例如 `https://www.yuque.com`，也可以是完整 API base URL，例如 `https://www.yuque.com/api/v2`。运行时会把站点根地址规范化到 `/api/v2`。不设置时默认 API base URL 为 `https://www.yuque.com/api/v2`。
+<details>
+<summary>从旧配置迁移？</summary>
 
----
+`YUQUE_PERSONAL_TOKEN`、`YUQUE_BASE_URL` 和 `--base-url` 仍作为兼容 fallback 生效。优先级：`YUQUE_TOKEN` > `YUQUE_PERSONAL_TOKEN` > `--token`；`YUQUE_HOST` > `--host` > `YUQUE_BASE_URL` > `--base-url`。新配置请使用 `YUQUE_TOKEN` 和 `YUQUE_HOST`。
 
-## 可用工具（19 个）
+</details>
 
-| 分类 | 工具 |
-|------|------|
-| **用户** | `yuque_get_user` |
-| **搜索** | `yuque_search` |
-| **知识库** | `yuque_list_books`、`yuque_get_book`、`yuque_create_book`、`yuque_update_book` |
-| **文档** | `yuque_list_docs`、`yuque_get_doc`、`yuque_create_doc`、`yuque_update_doc` |
-| **资源** | `yuque_get_resource`、`yuque_create_resource`、`yuque_update_resource` |
-| **目录** | `yuque_get_toc`、`yuque_update_toc` |
-| **小记** | `yuque_list_notes`、`yuque_get_note`、`yuque_create_note`、`yuque_update_note` |
+## 工具列表（19 个）
 
----
+| 分类   | 工具                    | 说明                                                            |
+| ------ | ----------------------- | ---------------------------------------------------------------- |
+| 用户   | `yuque_get_user`        | 获取当前 Token 对应的认证用户。                                 |
+| 搜索   | `yuque_search`          | 搜索文档或知识库（`type`：`doc` / `repo`），支持分页。          |
+| 知识库 | `yuque_list_books`      | 列出用户的知识库，默认当前用户。                                |
+|        | `yuque_get_book`        | 按 ID 或 namespace 获取知识库。                                 |
+|        | `yuque_create_book`     | 创建知识库。                                                    |
+|        | `yuque_update_book`     | 更新知识库的名称、slug、描述或公开状态。                        |
+| 文档   | `yuque_list_docs`       | 列出知识库下的文档，支持分页（单页上限 100）。                  |
+|        | `yuque_get_doc`         | 读取文档完整内容——默认 markdown，也可读取 `lake` / `html`。     |
+|        | `yuque_create_doc`      | 在知识库中创建文档。                                            |
+|        | `yuque_update_doc`      | 更新文档正文或元数据。                                          |
+| 目录   | `yuque_get_toc`         | 读取知识库目录。                                                |
+|        | `yuque_update_toc`      | 执行单个目录操作（追加或移动节点）。                            |
+| 小记   | `yuque_list_notes`      | 分页列出当前用户的小记，可按状态过滤。                          |
+|        | `yuque_get_note`        | 读取小记完整内容。                                              |
+|        | `yuque_create_note`     | 创建小记。                                                      |
+|        | `yuque_update_note`     | 更新小记。                                                      |
+| 画板   | `yuque_get_resource`    | 从文档中读取画板（思维导图 / 流程图 / 架构图）。                |
+|        | `yuque_create_resource` | 在文档中创建画板。                                              |
+|        | `yuque_update_resource` | 更新文档中的画板。                                              |
+
+每次调用只走一条语雀 API 链路。特别地，`yuque_update_doc` 不能在同一次调用里同时更新 markdown 正文和 `title` / `slug` / `public` 元数据，需要分两次调用。完整契约（包括 YMD markdown API 与 legacy document API 的路由规则）见 [docs/capability-scope.md](./docs/capability-scope.md)。
+
+**当前不支持：**评论读写、附件上传与文件管理、权限与成员管理、文档分段编辑，以及画板之外的结构化资源类型。
+
+## 写操作提示
+
+create / update 类工具会真实修改你知识库里的内容，server 的权限边界就是 Token 的权限边界。请妥善保管 Token；如果只操作某一个空间，建议使用绑定该空间的团队 Token（配合 `YUQUE_HOST`）。发现安全问题请查看 [SECURITY.md](./SECURITY.md)。
 
 ## 常见问题
 
-| 错误 | 解决方案 |
-|------|----------|
-| `YUQUE_TOKEN ... is required` | 设置 `YUQUE_TOKEN=YOUR_TOKEN` 或传入 `--token=YOUR_TOKEN` |
-| `401 Unauthorized` | Token 无效或已过期 — 到[语雀设置](https://www.yuque.com/settings/tokens)重新生成 |
-| `429 Rate Limited` | 请求过于频繁，等待后重试 |
-| 找不到工具 | 更新到最新版本：`npx -y yuque-mcp@latest` |
-| 找不到 `npx` 命令 | 安装 [Node.js](https://nodejs.org/)（v18 或更高版本） |
-
----
+| 错误                          | 解决方案                                                                             |
+| ----------------------------- | ------------------------------------------------------------------------------------ |
+| `YUQUE_TOKEN ... is required` | 设置 `YUQUE_TOKEN=YOUR_TOKEN` 或传入 `--token=YOUR_TOKEN`。                          |
+| `401 Unauthorized`            | Token 无效或已过期——到[语雀设置](https://www.yuque.com/settings/tokens)重新生成。    |
+| `429 Rate Limited`            | 请求过于频繁，稍等后重试。                                                           |
+| `410 Gone`                    | 资源已被永久删除或 API 端点已废弃——确认目标文档 / 知识库仍然存在。                   |
+| 找不到工具                    | 更新到最新版本：`npx -y yuque-mcp@latest`。                                          |
+| 找不到 `npx` 命令             | 安装 [Node.js](https://nodejs.org/)（v18 或更高版本）。                              |
 
 ## 开发
 
@@ -263,15 +124,13 @@ npm run build         # 编译 TypeScript
 npm run dev           # 开发模式（热重载）
 ```
 
----
+架构、技术栈和完整工具契约见 [docs/](./docs/README.md)。欢迎贡献——见 [CONTRIBUTING.md](./CONTRIBUTING.md)。
 
 ## 链接
 
-- [官网](https://yuque.github.io/yuque-ecosystem/)
 - [语雀 API 文档](https://www.yuque.com/yuque/developer/api)
-- [MCP 协议](https://modelcontextprotocol.io/)
-- [MCP Registry](https://github.com/modelcontextprotocol/servers)
-- [贡献指南](./CONTRIBUTING.md)
+- [Model Context Protocol](https://modelcontextprotocol.io/)
+- [Yuque AI Ecosystem](https://yuque.github.io/yuque-ecosystem/)——基于本 server 构建的 Skills 与 Plugin
 
 ## 许可证
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Project Documentation
 
-这个目录放项目级维护文档，重点描述当前代码的真实边界，而不是安装说明。安装和用户接入请优先看根目录 `README.md` / `README.zh-CN.md`。
+这个目录放项目级维护文档，重点描述当前代码的真实边界，而不是安装说明。安装和用户接入请优先看根目录 `README.md` / `README.zh-CN.md`；各 MCP 客户端的手动配置路径见 [Client Configuration](./clients.md)。
 
 ## 阅读顺序
 
@@ -21,3 +21,5 @@
 - 改动 runtime、认证、host/base URL、CLI 入口或发布链路时，同步更新 [Technical Stack](./technical-stack.md)。
 - 改动入口、transport（传输层）、tool 注册、client 封装或数据流时，同步更新 [Core Architecture](./core-architecture.md)。
 - 新增、删除或修改 MCP tool、参数 schema、格式 enum 或资源类型时，同步更新 [Capability Scope](./capability-scope.md)，并确认 `tests/mcp/tool-registry-contract.test.ts` 覆盖对应 contract（契约）。
+- 根目录两份 README 的工具表由 `tests/docs/tool-surface-docs.test.ts` 锁定，[Capability Scope](./capability-scope.md) 由 `tests/mcp/capability-scope-docs.test.ts` 锁定，tool surface 变化时按测试失败提示同步更新文档。
+- 改动用户可见配置（环境变量、CLI 参数、支持的客户端列表）时，同步更新 `README.md`、`README.zh-CN.md` 和 [Client Configuration](./clients.md)；两份 README 保持逐节对应。

--- a/docs/clients.md
+++ b/docs/clients.md
@@ -1,0 +1,121 @@
+# Client Configuration
+
+Manual MCP configuration for every supported client. In most cases you do not need this page — the installer writes these files for you:
+
+```bash
+npx yuque-mcp install --token=YOUR_TOKEN --client=<client>
+```
+
+Every stdio MCP client uses the same server entry; only the config file location and top-level key differ:
+
+```json
+{
+  "command": "npx",
+  "args": ["-y", "yuque-mcp"],
+  "env": { "YUQUE_TOKEN": "YOUR_TOKEN" }
+}
+```
+
+For team tokens or private deployments, add `"YUQUE_HOST": "https://your-space.yuque.com"` to `env`.
+
+## Claude Code
+
+```bash
+claude mcp add yuque -- npx -y yuque-mcp --token=YOUR_TOKEN
+```
+
+Or with environment variables:
+
+```bash
+export YUQUE_TOKEN=YOUR_TOKEN
+claude mcp add yuque -- npx -y yuque-mcp
+```
+
+## Claude Desktop
+
+Config file (`mcpServers` key):
+
+- macOS: `~/Library/Application Support/Claude/claude_desktop_config.json`
+- Windows: `%APPDATA%\Claude\claude_desktop_config.json`
+- Linux: `~/.config/Claude/claude_desktop_config.json`
+
+```json
+{
+  "mcpServers": {
+    "yuque": {
+      "command": "npx",
+      "args": ["-y", "yuque-mcp"],
+      "env": { "YUQUE_TOKEN": "YOUR_TOKEN" }
+    }
+  }
+}
+```
+
+## VS Code (GitHub Copilot)
+
+`.vscode/mcp.json` in your workspace — note the top-level key is `servers`, not `mcpServers`:
+
+```json
+{
+  "servers": {
+    "yuque": {
+      "command": "npx",
+      "args": ["-y", "yuque-mcp"],
+      "env": { "YUQUE_TOKEN": "YOUR_TOKEN" }
+    }
+  }
+}
+```
+
+Then enable Agent mode in GitHub Copilot Chat.
+
+## Cursor
+
+`~/.cursor/mcp.json` (`mcpServers` key), same entry as Claude Desktop.
+
+## Windsurf
+
+`~/.windsurf/mcp.json` (`mcpServers` key), same entry as Claude Desktop.
+
+## Cline (VS Code extension)
+
+Config file (`mcpServers` key), same entry as Claude Desktop:
+
+- macOS: `~/Library/Application Support/Code/User/globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json`
+- Windows: `%APPDATA%\Code\User\globalStorage\saoudrizwan.claude-dev\settings\cline_mcp_settings.json`
+- Linux: `~/.config/Code/User/globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json`
+
+## Trae
+
+In Trae, open **Settings → MCP** and add a stdio server with command `npx`, args `-y yuque-mcp`, env `YUQUE_TOKEN=YOUR_TOKEN`. See the [Trae MCP documentation](https://docs.trae.ai/ide/model-context-protocol) for details.
+
+The installer writes to (`mcpServers` key):
+
+- macOS: `~/Library/Application Support/Trae/User/globalStorage/trae-ai.trae-core/settings/cline_mcp_settings.json`
+- Windows: `%APPDATA%\Trae\User\globalStorage\trae-ai.trae-core\settings\cline_mcp_settings.json`
+- Linux: `~/.config/Trae/User/globalStorage/trae-ai.trae-core/settings/cline_mcp_settings.json`
+
+## Qoder
+
+`~/.qoder/mcp.json` (`mcpServers` key), same entry as Claude Desktop.
+
+## OpenCode
+
+`opencode.json` in your project root — OpenCode uses its own schema:
+
+```json
+{
+  "mcp": {
+    "yuque": {
+      "type": "local",
+      "command": ["npx", "-y", "yuque-mcp"],
+      "environment": { "YUQUE_TOKEN": "YOUR_TOKEN" },
+      "enabled": true
+    }
+  }
+}
+```
+
+## Other clients
+
+Any MCP client that supports stdio transport works: command `npx`, args `["-y", "yuque-mcp"]`, env `YUQUE_TOKEN` (plus `YUQUE_HOST` if needed).

--- a/tests/docs/tool-surface-docs.test.ts
+++ b/tests/docs/tool-surface-docs.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { userTools } from '../../src/tools/user.js';
+import { bookTools } from '../../src/tools/book.js';
+import { docTools } from '../../src/tools/doc.js';
+import { tocTools } from '../../src/tools/toc.js';
+import { searchTools } from '../../src/tools/search.js';
+import { noteTools } from '../../src/tools/note.js';
+import { resourceTools } from '../../src/tools/resource.js';
+
+const registeredToolNames = Object.keys({
+  ...userTools,
+  ...bookTools,
+  ...docTools,
+  ...tocTools,
+  ...searchTools,
+  ...noteTools,
+  ...resourceTools,
+}).sort();
+
+// READMEs that list the public tool surface. Each must show the exact tool
+// count and name every registered tool (and nothing else) inside its tools
+// section. docs/capability-scope.md has its own lock in
+// tests/mcp/capability-scope-docs.test.ts.
+const docContracts = [
+  {
+    file: 'README.md',
+    countPattern: /^## Tools \((\d+)\)$/m,
+    sectionHeading: '## Tools (',
+  },
+  {
+    file: 'README.zh-CN.md',
+    countPattern: /^## 工具列表（(\d+) 个）$/m,
+    sectionHeading: '## 工具列表（',
+  },
+];
+
+function readRepoFile(relativePath: string): string {
+  return readFileSync(fileURLToPath(new URL(`../../${relativePath}`, import.meta.url)), 'utf-8');
+}
+
+function extractSection(content: string, heading: string): string {
+  const start = content.indexOf(heading);
+  if (start === -1) throw new Error(`Heading not found: ${heading}`);
+  const rest = content.slice(start + heading.length);
+  const nextHeading = rest.search(/^## /m);
+  return nextHeading === -1 ? rest : rest.slice(0, nextHeading);
+}
+
+function extractToolNames(section: string): string[] {
+  const names = [...section.matchAll(/`(yuque_[a-z_]+)`/g)].map((match) => match[1]);
+  return [...new Set(names)].sort();
+}
+
+describe('tool surface documentation contract', () => {
+  for (const contract of docContracts) {
+    it(`${contract.file} lists the complete tool surface`, () => {
+      const content = readRepoFile(contract.file);
+
+      const countMatch = content.match(contract.countPattern);
+      if (!countMatch) throw new Error(`Tool count marker missing in ${contract.file}`);
+      expect(Number(countMatch[1])).toBe(registeredToolNames.length);
+
+      const section = extractSection(content, contract.sectionHeading);
+      expect(extractToolNames(section)).toEqual(registeredToolNames);
+    });
+  }
+});


### PR DESCRIPTION
## Summary

Reworks the project's front page from a config manual into a product introduction, and makes docs/code tool-surface drift fail CI:

- **README.md / README.zh-CN.md rewritten** (~280 → ~150 lines each): value-first intro with three example prompts, a one-line description for every tool, explicit capability boundaries ("not covered yet"), a write-access note linking SECURITY.md, and an npm downloads badge. Legacy `YUQUE_PERSONAL_TOKEN` / `YUQUE_BASE_URL` guidance folded into a collapsed migration block. The two READMEs are written per-language but kept section-by-section in sync — this also fixes the `410 Gone` troubleshooting row missing from the zh version.
- **Per-client manual configs moved to `docs/clients.md`**, with macOS / Windows / Linux paths taken from `src/cli-install.ts` (the old README only had macOS paths for Cline/Trae, and its client list didn't match the installer's). Server key unified as `yuque` — what the installer actually writes.
- **New `tests/docs/tool-surface-docs.test.ts`** locks both README tool tables (names + declared count) to the registered tool surface, complementing `tests/mcp/capability-scope-docs.test.ts` which already locks `docs/capability-scope.md`.
- **`docs/README.md` maintenance conventions updated** for the new files and the test split.

## Test plan

- [x] `npm run check` green end-to-end (lint + format:check + typecheck + 186 tests + build)
- [x] Doc-contract test verified: tool-table drift in either README fails with the exact expected/actual diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)