### PR TITLE
docs: redesign READMEs with centered header and slimmer tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,16 @@
-# Yuque MCP Server
+<div align="center">
 
-[![CI](https://github.com/yuque/yuque-mcp-server/actions/workflows/ci.yml/badge.svg)](https://github.com/yuque/yuque-mcp-server/actions/workflows/ci.yml)
-[![npm version](https://img.shields.io/npm/v/yuque-mcp)](https://www.npmjs.com/package/yuque-mcp)
-[![npm downloads](https://img.shields.io/npm/dm/yuque-mcp)](https://www.npmjs.com/package/yuque-mcp)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](./LICENSE)
+<a href="https://www.yuque.com/"><img src="https://avatars.githubusercontent.com/u/34602419?s=200&v=4" width="96" alt="Yuque logo"></a>
 
-Let AI assistants read and write your [Yuque (语雀)](https://www.yuque.com/) knowledge base through the [Model Context Protocol](https://modelcontextprotocol.io/).
+<h1>Yuque MCP Server</h1>
 
-[中文文档](./README.zh-CN.md)
+Let AI assistants read and write your [Yuque (语雀)](https://www.yuque.com/) knowledge base<br>through the [Model Context Protocol](https://modelcontextprotocol.io/).
+
+[![CI][ci-image]][ci-url] [![npm version][npm-image]][npm-url] [![npm downloads][download-image]][download-url] [![License][license-image]][license-url]
+
+[Quick Start](#quick-start) · [Tools](#tools-19) · [Troubleshooting](#troubleshooting) · [Docs](./docs/README.md) · [中文文档](./README.zh-CN.md)
+
+</div>
 
 Once connected, ask your assistant things like:
 
@@ -19,23 +22,31 @@ Once connected, ask your assistant things like:
 
 ## Quick Start
 
-**1. Get a token.** Create one at [Yuque Developer Settings](https://www.yuque.com/settings/tokens). If you use a team token bound to a Yuque space, also note the space host (for example `https://your-space.yuque.com`) — you will pass it as `--host`.
+**1. Get a token** — create one at [Yuque Developer Settings](https://www.yuque.com/settings/tokens). If you use a team token bound to a Yuque space, also note the space host (e.g. `https://your-space.yuque.com`) — you will pass it as `--host`.
 
-**2. Install.** One command configures your client:
+**2. Install** — one command locates the right config file for your OS and merges a `yuque` entry into it, without touching other servers:
 
 ```bash
 npx yuque-mcp install --token=YOUR_TOKEN --client=cursor
 ```
 
-Supported clients: `claude-desktop`, `vscode`, `cursor`, `windsurf`, `cline`, `trae`, `qoder`, `opencode`. The installer locates the right config file for your OS and merges a `yuque` entry into it without touching other servers. Prefer an interactive flow? Run `npx yuque-mcp setup`.
+Supported clients: `claude-desktop` · `vscode` · `cursor` · `windsurf` · `cline` · `trae` · `qoder` · `opencode`. Prefer an interactive flow? Run `npx yuque-mcp setup`.
 
-Using Claude Code? Register the server directly:
+<details>
+<summary><b>Claude Code</b></summary>
+
+Register the server directly:
 
 ```bash
 claude mcp add yuque -- npx -y yuque-mcp --token=YOUR_TOKEN
 ```
 
-Any other MCP client that supports stdio transport works too — see [docs/clients.md](./docs/clients.md) for per-client config paths, or use the generic entry:
+</details>
+
+<details>
+<summary><b>Other MCP clients (generic config)</b></summary>
+
+Any client that supports stdio transport works — see [docs/clients.md](./docs/clients.md) for per-client config paths.
 
 ```json
 {
@@ -49,14 +60,18 @@ Any other MCP client that supports stdio transport works too — see [docs/clien
 }
 ```
 
+</details>
+
 **3. Restart your client** and start asking.
 
 ## Configuration
 
-| Setting          | Env var / CLI flag        | Description                                                                                                                                                                                                                              |
-| ---------------- | ------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Token (required) | `YUQUE_TOKEN` / `--token` | Personal or team Yuque API token.                                                                                                                                                                                                        |
-| Host (optional)  | `YUQUE_HOST` / `--host`   | Yuque site or space host, e.g. `https://your-space.yuque.com`. Required for team tokens bound to a space and for private deployments. Site roots are normalized to `/api/v2`; defaults to `https://www.yuque.com/api/v2` when not set. |
+| Setting              | Env var / CLI flag        | Description                                                                                                     |
+| -------------------- | ------------------------- | --------------------------------------------------------------------------------------------------------------- |
+| Token **(required)** | `YUQUE_TOKEN` / `--token` | Personal or team Yuque API token                                                                                |
+| Host (optional)      | `YUQUE_HOST` / `--host`   | Site or space host, e.g. `https://your-space.yuque.com` — required for space-bound team tokens and private deployments |
+
+Site roots are normalized to `/api/v2`; when unset, the host defaults to `https://www.yuque.com/api/v2`.
 
 ```bash
 # Team token / private deployment
@@ -72,29 +87,31 @@ npx yuque-mcp install --token=YOUR_TOKEN --client=cursor --host=https://your-spa
 
 ## Tools (19)
 
-| Category  | Tool                    | What it does                                                                 |
-| --------- | ----------------------- | ---------------------------------------------------------------------------- |
-| User      | `yuque_get_user`        | Get the authenticated user for the current token.                            |
-| Search    | `yuque_search`          | Search docs or repos (`type`: `doc` / `repo`), with optional paging.         |
-| Books     | `yuque_list_books`      | List books (知识库) of a user; defaults to the current user.                 |
-|           | `yuque_get_book`        | Get a book by ID or namespace.                                               |
-|           | `yuque_create_book`     | Create a book.                                                               |
-|           | `yuque_update_book`     | Update a book's name, slug, description, or visibility.                      |
-| Docs      | `yuque_list_docs`       | List docs in a book, with paging (max 100 per page).                         |
-|           | `yuque_get_doc`         | Get a doc with full content — markdown by default, `lake` / `html` on request. |
-|           | `yuque_create_doc`      | Create a doc in a book.                                                      |
-|           | `yuque_update_doc`      | Update a doc's body or metadata.                                             |
-| TOC       | `yuque_get_toc`         | Get a book's table of contents.                                              |
-|           | `yuque_update_toc`      | Apply a single TOC operation (append or move a node).                        |
-| Notes     | `yuque_list_notes`      | List your notes (小记), with paging and status filter.                       |
-|           | `yuque_get_note`        | Get a note with full content.                                                |
-|           | `yuque_create_note`     | Create a note.                                                               |
-|           | `yuque_update_note`     | Update a note.                                                               |
-| Resources | `yuque_get_resource`    | Read a board (mindmap / flowchart / architecture diagram) from a doc.        |
-|           | `yuque_create_resource` | Create a board in a doc.                                                     |
-|           | `yuque_update_resource` | Update a board in a doc.                                                     |
+Each tool maps to exactly one Yuque API route.
 
-Each call uses exactly one Yuque API route. In particular, `yuque_update_doc` cannot combine a markdown body with `title` / `slug` / `public` changes in a single call — update metadata separately. The full contract, including format routing between the YMD markdown API and the legacy document API, is documented in [docs/capability-scope.md](./docs/capability-scope.md).
+| Category    | Tool                    | Description                                              |
+| ----------- | ----------------------- | -------------------------------------------------------- |
+| **User**    | `yuque_get_user`        | Get the authenticated user for the current token         |
+| **Search**  | `yuque_search`          | Search docs or repos, with paging                        |
+| **Books**   | `yuque_list_books`      | List books (知识库) of a user                            |
+|             | `yuque_get_book`        | Get a book by ID or namespace                            |
+|             | `yuque_create_book`     | Create a book                                            |
+|             | `yuque_update_book`     | Update name, slug, description, or visibility            |
+| **Docs**    | `yuque_list_docs`       | List docs in a book, with paging                         |
+|             | `yuque_get_doc`         | Get full content — markdown, `lake`, or `html`           |
+|             | `yuque_create_doc`      | Create a doc in a book                                   |
+|             | `yuque_update_doc`      | Update a doc's body or metadata                          |
+| **TOC**     | `yuque_get_toc`         | Get a book's table of contents                           |
+|             | `yuque_update_toc`      | Append or move a single TOC node                         |
+| **Notes**   | `yuque_list_notes`      | List notes (小记), with paging and status filter         |
+|             | `yuque_get_note`        | Get a note with full content                             |
+|             | `yuque_create_note`     | Create a note                                            |
+|             | `yuque_update_note`     | Update a note                                            |
+| **Boards**  | `yuque_get_resource`    | Read a board (mindmap / flowchart / diagram) from a doc  |
+|             | `yuque_create_resource` | Create a board in a doc                                  |
+|             | `yuque_update_resource` | Update a board in a doc                                  |
+
+In particular, `yuque_update_doc` cannot combine a markdown body with `title` / `slug` / `public` changes in a single call — update metadata separately. The full contract, including format routing between the YMD markdown API and the legacy document API, is documented in [docs/capability-scope.md](./docs/capability-scope.md).
 
 **Not covered (yet):** comments, attachment upload and file management, permission and member management, section-level doc edits, and structured resources other than boards.
 
@@ -104,14 +121,14 @@ The create/update tools modify real content in your knowledge base, and the serv
 
 ## Troubleshooting
 
-| Error                         | Solution                                                                                                             |
-| ----------------------------- | -------------------------------------------------------------------------------------------------------------------- |
-| `YUQUE_TOKEN ... is required` | Set `YUQUE_TOKEN=YOUR_TOKEN` or pass `--token=YOUR_TOKEN`.                                                            |
-| `401 Unauthorized`            | Token is invalid or expired — regenerate at [Yuque Settings](https://www.yuque.com/settings/tokens).                  |
-| `429 Rate Limited`            | Too many requests — wait a moment and retry.                                                                          |
-| `410 Gone`                    | The resource has been permanently deleted or the API endpoint is deprecated — verify the target doc/book still exists. |
-| Tool not found                | Update to the latest version: `npx -y yuque-mcp@latest`.                                                              |
-| `npx` command not found       | Install [Node.js](https://nodejs.org/) (v18 or later).                                                                |
+| Error                         | Solution                                                                     |
+| ----------------------------- | ----------------------------------------------------------------------------- |
+| `YUQUE_TOKEN ... is required` | Set `YUQUE_TOKEN=YOUR_TOKEN` or pass `--token=YOUR_TOKEN`                     |
+| `401 Unauthorized`            | Token invalid or expired — [regenerate it](https://www.yuque.com/settings/tokens) |
+| `429 Rate Limited`            | Too many requests — wait a moment and retry                                   |
+| `410 Gone`                    | Target permanently deleted or endpoint deprecated — check the doc/book exists |
+| Tool not found                | Update to the latest version: `npx -y yuque-mcp@latest`                       |
+| `npx` command not found       | Install [Node.js](https://nodejs.org/) v18 or later                           |
 
 ## Development
 
@@ -135,3 +152,12 @@ Architecture, tech stack, and the full tool contract live in [docs/](./docs/READ
 ## License
 
 [MIT](./LICENSE)
+
+[ci-image]: https://img.shields.io/github/actions/workflow/status/yuque/yuque-mcp-server/ci.yml?style=flat-square&label=CI
+[ci-url]: https://github.com/yuque/yuque-mcp-server/actions/workflows/ci.yml
+[npm-image]: https://img.shields.io/npm/v/yuque-mcp?style=flat-square
+[npm-url]: https://www.npmjs.com/package/yuque-mcp
+[download-image]: https://img.shields.io/npm/dm/yuque-mcp?style=flat-square
+[download-url]: https://www.npmjs.com/package/yuque-mcp
+[license-image]: https://img.shields.io/github/license/yuque/yuque-mcp-server?style=flat-square
+[license-url]: ./LICENSE

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,13 +1,16 @@
-# Yuque MCP Server
+<div align="center">
 
-[![CI](https://github.com/yuque/yuque-mcp-server/actions/workflows/ci.yml/badge.svg)](https://github.com/yuque/yuque-mcp-server/actions/workflows/ci.yml)
-[![npm version](https://img.shields.io/npm/v/yuque-mcp)](https://www.npmjs.com/package/yuque-mcp)
-[![npm downloads](https://img.shields.io/npm/dm/yuque-mcp)](https://www.npmjs.com/package/yuque-mcp)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](./LICENSE)
+<a href="https://www.yuque.com/"><img src="https://avatars.githubusercontent.com/u/34602419?s=200&v=4" width="96" alt="语雀 logo"></a>
 
-让 Claude、Cursor 等 AI 助手通过 [Model Context Protocol](https://modelcontextprotocol.io/) 直接读写你的[语雀](https://www.yuque.com/)知识库。
+<h1>Yuque MCP Server</h1>
 
-[English](./README.md)
+让 Claude、Cursor 等 AI 助手通过 [Model Context Protocol](https://modelcontextprotocol.io/)<br>直接读写你的[语雀](https://www.yuque.com/)知识库。
+
+[![CI][ci-image]][ci-url] [![npm version][npm-image]][npm-url] [![npm downloads][download-image]][download-url] [![License][license-image]][license-url]
+
+[快速开始](#快速开始) · [工具列表](#工具列表19-个) · [常见问题](#常见问题) · [文档](./docs/README.md) · [English](./README.md)
+
+</div>
 
 接入之后，你可以直接对 AI 助手说：
 
@@ -19,23 +22,31 @@
 
 ## 快速开始
 
-**第一步：获取 Token。**前往[语雀开发者设置](https://www.yuque.com/settings/tokens)创建个人访问令牌。如果使用绑定空间的团队 Token，记下空间地址（例如 `https://your-space.yuque.com`），稍后作为 `--host` 传入。
+**第一步：获取 Token** —— 前往[语雀开发者设置](https://www.yuque.com/settings/tokens)创建个人访问令牌。如果使用绑定空间的团队 Token，记下空间地址（例如 `https://your-space.yuque.com`），稍后作为 `--host` 传入。
 
-**第二步：一键安装。**一条命令完成客户端配置：
+**第二步：一键安装** —— 一条命令自动定位当前操作系统下的配置文件，把 `yuque` 条目合并进去，不影响已有的其他 server：
 
 ```bash
 npx yuque-mcp install --token=YOUR_TOKEN --client=cursor
 ```
 
-支持的客户端：`claude-desktop`、`vscode`、`cursor`、`windsurf`、`cline`、`trae`、`qoder`、`opencode`。安装器会自动定位当前操作系统下的配置文件，把 `yuque` 条目合并进去，不影响已有的其他 server。想要问答式引导？运行 `npx yuque-mcp setup`。
+支持的客户端：`claude-desktop` · `vscode` · `cursor` · `windsurf` · `cline` · `trae` · `qoder` · `opencode`。想要问答式引导？运行 `npx yuque-mcp setup`。
 
-Claude Code 用户直接注册：
+<details>
+<summary><b>Claude Code</b></summary>
+
+直接注册 server：
 
 ```bash
 claude mcp add yuque -- npx -y yuque-mcp --token=YOUR_TOKEN
 ```
 
-其他支持 stdio 传输的 MCP 客户端也都可以接入——各客户端的配置文件路径见 [docs/clients.md](./docs/clients.md)，通用配置如下：
+</details>
+
+<details>
+<summary><b>其他 MCP 客户端（通用配置）</b></summary>
+
+任何支持 stdio 传输的 MCP 客户端都可以接入——各客户端的配置文件路径见 [docs/clients.md](./docs/clients.md)。
 
 ```json
 {
@@ -49,14 +60,18 @@ claude mcp add yuque -- npx -y yuque-mcp --token=YOUR_TOKEN
 }
 ```
 
+</details>
+
 **第三步：重启客户端**，开始使用。
 
 ## 配置
 
-| 配置项        | 环境变量 / CLI 参数       | 说明                                                                                                                                                                                       |
-| ------------- | ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| Token（必填） | `YUQUE_TOKEN` / `--token` | 个人或团队语雀 API Token。                                                                                                                                                                 |
-| Host（可选）  | `YUQUE_HOST` / `--host`   | 语雀站点或空间地址，例如 `https://your-space.yuque.com`。绑定空间的团队 Token 和私有化部署必须设置。站点根地址会自动规范化为 `/api/v2`，不设置时默认 `https://www.yuque.com/api/v2`。 |
+| 配置项            | 环境变量 / CLI 参数       | 说明                                                                                       |
+| ----------------- | ------------------------- | ------------------------------------------------------------------------------------------ |
+| Token **（必填）** | `YUQUE_TOKEN` / `--token` | 个人或团队语雀 API Token                                                                   |
+| Host（可选）      | `YUQUE_HOST` / `--host`   | 语雀站点或空间地址，例如 `https://your-space.yuque.com`——绑定空间的团队 Token 和私有化部署必须设置 |
+
+站点根地址会自动规范化为 `/api/v2`，不设置时默认 `https://www.yuque.com/api/v2`。
 
 ```bash
 # 团队 Token / 私有化部署
@@ -72,29 +87,31 @@ npx yuque-mcp install --token=YOUR_TOKEN --client=cursor --host=https://your-spa
 
 ## 工具列表（19 个）
 
-| 分类   | 工具                    | 说明                                                            |
-| ------ | ----------------------- | ---------------------------------------------------------------- |
-| 用户   | `yuque_get_user`        | 获取当前 Token 对应的认证用户。                                 |
-| 搜索   | `yuque_search`          | 搜索文档或知识库（`type`：`doc` / `repo`），支持分页。          |
-| 知识库 | `yuque_list_books`      | 列出用户的知识库，默认当前用户。                                |
-|        | `yuque_get_book`        | 按 ID 或 namespace 获取知识库。                                 |
-|        | `yuque_create_book`     | 创建知识库。                                                    |
-|        | `yuque_update_book`     | 更新知识库的名称、slug、描述或公开状态。                        |
-| 文档   | `yuque_list_docs`       | 列出知识库下的文档，支持分页（单页上限 100）。                  |
-|        | `yuque_get_doc`         | 读取文档完整内容——默认 markdown，也可读取 `lake` / `html`。     |
-|        | `yuque_create_doc`      | 在知识库中创建文档。                                            |
-|        | `yuque_update_doc`      | 更新文档正文或元数据。                                          |
-| 目录   | `yuque_get_toc`         | 读取知识库目录。                                                |
-|        | `yuque_update_toc`      | 执行单个目录操作（追加或移动节点）。                            |
-| 小记   | `yuque_list_notes`      | 分页列出当前用户的小记，可按状态过滤。                          |
-|        | `yuque_get_note`        | 读取小记完整内容。                                              |
-|        | `yuque_create_note`     | 创建小记。                                                      |
-|        | `yuque_update_note`     | 更新小记。                                                      |
-| 画板   | `yuque_get_resource`    | 从文档中读取画板（思维导图 / 流程图 / 架构图）。                |
-|        | `yuque_create_resource` | 在文档中创建画板。                                              |
-|        | `yuque_update_resource` | 更新文档中的画板。                                              |
+每次调用只走一条语雀 API 链路。
 
-每次调用只走一条语雀 API 链路。特别地，`yuque_update_doc` 不能在同一次调用里同时更新 markdown 正文和 `title` / `slug` / `public` 元数据，需要分两次调用。完整契约（包括 YMD markdown API 与 legacy document API 的路由规则）见 [docs/capability-scope.md](./docs/capability-scope.md)。
+| 分类       | 工具                    | 说明                                          |
+| ---------- | ----------------------- | ---------------------------------------------- |
+| **用户**   | `yuque_get_user`        | 获取当前 Token 对应的认证用户                 |
+| **搜索**   | `yuque_search`          | 搜索文档或知识库，支持分页                    |
+| **知识库** | `yuque_list_books`      | 列出用户的知识库，默认当前用户                |
+|            | `yuque_get_book`        | 按 ID 或 namespace 获取知识库                 |
+|            | `yuque_create_book`     | 创建知识库                                    |
+|            | `yuque_update_book`     | 更新名称、slug、描述或公开状态                |
+| **文档**   | `yuque_list_docs`       | 列出知识库下的文档，支持分页                  |
+|            | `yuque_get_doc`         | 读取完整内容——默认 markdown，可选 `lake` / `html` |
+|            | `yuque_create_doc`      | 在知识库中创建文档                            |
+|            | `yuque_update_doc`      | 更新文档正文或元数据                          |
+| **目录**   | `yuque_get_toc`         | 读取知识库目录                                |
+|            | `yuque_update_toc`      | 追加或移动单个目录节点                        |
+| **小记**   | `yuque_list_notes`      | 分页列出小记，可按状态过滤                    |
+|            | `yuque_get_note`        | 读取小记完整内容                              |
+|            | `yuque_create_note`     | 创建小记                                      |
+|            | `yuque_update_note`     | 更新小记                                      |
+| **画板**   | `yuque_get_resource`    | 从文档中读取画板（思维导图 / 流程图 / 架构图）|
+|            | `yuque_create_resource` | 在文档中创建画板                              |
+|            | `yuque_update_resource` | 更新文档中的画板                              |
+
+特别地，`yuque_update_doc` 不能在同一次调用里同时更新 markdown 正文和 `title` / `slug` / `public` 元数据，需要分两次调用。完整契约（包括 YMD markdown API 与 legacy document API 的路由规则）见 [docs/capability-scope.md](./docs/capability-scope.md)。
 
 **当前不支持：**评论读写、附件上传与文件管理、权限与成员管理、文档分段编辑，以及画板之外的结构化资源类型。
 
@@ -104,14 +121,14 @@ create / update 类工具会真实修改你知识库里的内容，server 的权
 
 ## 常见问题
 
-| 错误                          | 解决方案                                                                             |
-| ----------------------------- | ------------------------------------------------------------------------------------ |
-| `YUQUE_TOKEN ... is required` | 设置 `YUQUE_TOKEN=YOUR_TOKEN` 或传入 `--token=YOUR_TOKEN`。                          |
-| `401 Unauthorized`            | Token 无效或已过期——到[语雀设置](https://www.yuque.com/settings/tokens)重新生成。    |
-| `429 Rate Limited`            | 请求过于频繁，稍等后重试。                                                           |
-| `410 Gone`                    | 资源已被永久删除或 API 端点已废弃——确认目标文档 / 知识库仍然存在。                   |
-| 找不到工具                    | 更新到最新版本：`npx -y yuque-mcp@latest`。                                          |
-| 找不到 `npx` 命令             | 安装 [Node.js](https://nodejs.org/)（v18 或更高版本）。                              |
+| 错误                          | 解决方案                                                              |
+| ----------------------------- | ---------------------------------------------------------------------- |
+| `YUQUE_TOKEN ... is required` | 设置 `YUQUE_TOKEN=YOUR_TOKEN` 或传入 `--token=YOUR_TOKEN`             |
+| `401 Unauthorized`            | Token 无效或已过期——到[语雀设置](https://www.yuque.com/settings/tokens)重新生成 |
+| `429 Rate Limited`            | 请求过于频繁，稍等后重试                                              |
+| `410 Gone`                    | 资源已被永久删除或 API 端点已废弃——确认目标文档 / 知识库仍然存在      |
+| 找不到工具                    | 更新到最新版本：`npx -y yuque-mcp@latest`                             |
+| 找不到 `npx` 命令             | 安装 [Node.js](https://nodejs.org/)（v18 或更高版本）                 |
 
 ## 开发
 
@@ -135,3 +152,12 @@ npm run dev           # 开发模式（热重载）
 ## 许可证
 
 [MIT](./LICENSE)
+
+[ci-image]: https://img.shields.io/github/actions/workflow/status/yuque/yuque-mcp-server/ci.yml?style=flat-square&label=CI
+[ci-url]: https://github.com/yuque/yuque-mcp-server/actions/workflows/ci.yml
+[npm-image]: https://img.shields.io/npm/v/yuque-mcp?style=flat-square
+[npm-url]: https://www.npmjs.com/package/yuque-mcp
+[download-image]: https://img.shields.io/npm/dm/yuque-mcp?style=flat-square
+[download-url]: https://www.npmjs.com/package/yuque-mcp
+[license-image]: https://img.shields.io/github/license/yuque/yuque-mcp-server?style=flat-square
+[license-url]: ./LICENSE


### PR DESCRIPTION
### What does this PR do?

Visual redesign of `README.md` and `README.zh-CN.md`, aligning them with the conventions of well-regarded OSS readmes (khoj, ant-design, context7). Content and the locked tool surface are unchanged — this is layout and phrasing only.

- **Centered header block**: official Yuque logo (GitHub org avatar, no dependency on Yuque CDN), title, two-line tagline, badges unified to `flat-square` style on a single row, and a dot-separated nav row that now hosts the language-switch link (previously a stranded one-line paragraph).
- **Quick Start slimmed**: the primary installer path stays visible; Claude Code and generic JSON config are folded into `<details>`.
- **Tables de-walled**: cells reduced to short phrases so rows keep even heights; long explanations (host normalization/default, the `yuque_update_doc` single-route constraint) moved to prose around the tables.
- **EN / zh-CN kept structurally identical**, including badges, collapsible blocks, and table layout.

The tool-surface contract test (`tests/docs/tool-surface-docs.test.ts`) caught an early draft that dropped the count from the tools heading — restored `## Tools (19)` / `## 工具列表（19 个）` and adjusted nav anchors accordingly.

Rendered output was verified screen-by-screen with the GitHub markdown API (`gh api markdown`) in a browser for both languages.

### Related Issues

N/A

### Type of Change

- [ ] 🐞 Bug fix
- [ ] ✨ New feature
- [x] 📝 Documentation update
- [ ] ♻️ Refactoring
- [ ] ⚡️ Performance improvement

### Checklist

- [x] `npm run check` passes locally
- [ ] Tests added / updated
- [x] Documentation updated (if applicable)
- [ ] Changelog entry added (if user-facing)
- [x] No breaking changes (or documented in description)

### Changelog Entry

N/A — repository documentation only, no package behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)